### PR TITLE
fix(ci): disable npm publishing in semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,12 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
     [
       "@semantic-release/exec",
       {


### PR DESCRIPTION
## Overview
Disables the default npm publishing behavior in semantic-release.

## Fixes
- Fixes `ENONPMTOKEN` error in CI workflow.
- Ensures semantic-release only updates `package.json` version but does not attempt to push to registry.npmjs.org.

