### PR TITLE
fix(docs): add branch parameter to github actions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 <p align="center" class="mdview-badges">
   <a href="https://github.com/jamesainslie/mdview/actions/workflows/ci.yml">
-    <img src="https://github.com/jamesainslie/mdview/actions/workflows/ci.yml/badge.svg" alt="CI Status" />
+    <img src="https://github.com/jamesainslie/mdview/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI Status" />
   </a>
   <a href="https://github.com/jamesainslie/mdview/actions/workflows/release-please.yml">
-    <img src="https://github.com/jamesainslie/mdview/actions/workflows/release-please.yml/badge.svg" alt="Release Please" />
+    <img src="https://github.com/jamesainslie/mdview/actions/workflows/release-please.yml/badge.svg?branch=main" alt="Release Please" />
   </a>
   <a href="https://github.com/jamesainslie/mdview/actions/workflows/release-extension.yml">
-    <img src="https://github.com/jamesainslie/mdview/actions/workflows/release-extension.yml/badge.svg" alt="Release Extension" />
+    <img src="https://github.com/jamesainslie/mdview/actions/workflows/release-extension.yml/badge.svg?branch=main&event=push" alt="Release Extension" />
   </a>
-  <img src="https://img.shields.io/github/package-json/v/jamesainslie/mdview" alt="Version" />
+  <img src="https://img.shields.io/github/package-json/v/jamesainslie/mdview?branch=main" alt="Version" />
   <img src="https://img.shields.io/github/license/jamesainslie/mdview" alt="License" />
 </p>
 


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file to ensure that the badges for CI status, releases, and version always reflect the status of the `main` branch. This change helps provide more accurate and relevant status indicators for users viewing the project.GitHub Actions badges require the branch parameter to display accurate status for specific branches. Without this parameter, badges may show incorrect or no status until workflows run on the default branch. The release-extension badge also includes event=push to filter by push events since the workflow is tag-triggered.