### PR TITLE
docs(readme): remove non-working ci badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
   <a href="https://github.com/jamesainslie/mdview/actions/workflows/release-please.yml">
     <img src="https://github.com/jamesainslie/mdview/actions/workflows/release-please.yml/badge.svg?branch=main" alt="Release Please" />
   </a>
-  <a href="https://github.com/jamesainslie/mdview/actions/workflows/release-extension.yml">
-    <img src="https://github.com/jamesainslie/mdview/actions/workflows/release-extension.yml/badge.svg?branch=main&event=push" alt="Release Extension" />
-  </a>
   <img src="https://img.shields.io/github/package-json/v/jamesainslie/mdview?branch=main" alt="Version" />
-  <img src="https://img.shields.io/github/license/jamesainslie/mdview" alt="License" />
 </p>
 
 <p align="center" class="mdview-logo-wrapper">


### PR DESCRIPTION
## Summary

Remove two non-functional CI badges from README that display error states: Release Extension workflow badge shows "no status" and License badge shows "not specified".

## Changes

- Remove Release Extension workflow badge (displays "no status")
- Remove License badge (displays "not specified") 
- Retain three functional badges: CI Status, Release Please, and Version

## Type

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Performance
- [ ] CI/CD
- [ ] Other: ___

## Testing

- No code changes, documentation only
- Verified remaining badges display correctly

## Breaking Changes

None

## Related Issues

None