### PR TITLE
Fix mermaid DOCX export and add Electron features

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
       "devDependencies": {
         "@types/dompurify": "^3.0.5",
         "@types/markdown-it": "^13.0.9",
+        "jszip": "^3.10.1",
       },
     },
     "packages/electron": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,8 @@
   },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
-    "@types/markdown-it": "^13.0.9"
+    "@types/markdown-it": "^13.0.9",
+    "jszip": "^3.10.1"
   },
   "author": "James Ainslie",
   "license": "MIT"

--- a/packages/core/src/__tests__/docx-export-integration.test.ts
+++ b/packages/core/src/__tests__/docx-export-integration.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Integration tests for the full DOCX export pipeline.
+ *
+ * These tests wire ContentCollector → SVGConverter → DOCXGenerator against
+ * realistic DOM structures and verify the generated DOCX blob is correct.
+ *
+ * They exist to catch two specific regressions:
+ *   1. Mermaid diagrams silently missing from DOCX output
+ *   2. Large documents with progressive hydration exporting only headings
+ */
+import { describe, it, expect } from 'vitest';
+import { ContentCollector } from '../utils/content-collector';
+import { SVGConverter } from '../utils/svg-converter';
+import { DOCXGenerator } from '../utils/docx-generator';
+import JSZip from 'jszip';
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+/** Unzip a DOCX blob and return the main document.xml content as text. */
+async function extractDocumentXml(blob: Blob): Promise<string> {
+  // JSDOM Blob may not have arrayBuffer(), so read via FileReader-style workaround
+  const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as ArrayBuffer);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsArrayBuffer(blob);
+  });
+  const zip = await JSZip.loadAsync(buffer);
+  const docXml = zip.file('word/document.xml');
+  if (!docXml) throw new Error('document.xml not found in DOCX');
+  return docXml.async('text');
+}
+
+/** Count occurrences of a substring in text. */
+function countOccurrences(text: string, substring: string): number {
+  let count = 0;
+  let pos = 0;
+  while ((pos = text.indexOf(substring, pos)) !== -1) {
+    count++;
+    pos += substring.length;
+  }
+  return count;
+}
+
+/**
+ * Run the full export pipeline on a container: collect → convert SVGs → generate DOCX.
+ * Returns the blob and the raw document.xml text.
+ */
+async function exportContainer(container: HTMLElement) {
+  const collector = new ContentCollector();
+  const content = collector.collect(container);
+
+  const svgElements = Array.from(container.querySelectorAll<SVGElement>('.mermaid-container svg'));
+  const converter = new SVGConverter();
+  const images = converter.convertAll(svgElements);
+
+  const generator = new DOCXGenerator();
+  const blob = await generator.generate(content, images, { title: content.title });
+
+  const xml = await extractDocumentXml(blob);
+  return { blob, xml, content, images };
+}
+
+// ── tests ────────────────────────────────────────────────────────────
+
+describe('DOCX export integration — mermaid diagrams', () => {
+  it('should include mermaid diagram images in the generated DOCX', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <h1>Architecture</h1>
+      <p>Here is the system diagram:</p>
+      <div class="mermaid-container mermaid-ready" id="mermaid-arch1">
+        <div class="mermaid-rendered">
+          <svg width="400" height="200" viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg">
+            <rect width="400" height="200" fill="#f0f0f0"/>
+            <text x="200" y="100" text-anchor="middle">System</text>
+          </svg>
+        </div>
+      </div>
+      <p>And a sequence diagram:</p>
+      <div class="mermaid-container mermaid-ready" id="mermaid-seq1">
+        <div class="mermaid-rendered">
+          <svg width="300" height="150" viewBox="0 0 300 150" xmlns="http://www.w3.org/2000/svg">
+            <rect width="300" height="150" fill="#e0e0e0"/>
+            <text x="150" y="75" text-anchor="middle">Sequence</text>
+          </svg>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(container);
+
+    const { blob, xml, content, images } = await exportContainer(container);
+
+    // ── content collector found both diagrams
+    const mermaidNodes = content.nodes.filter((n) => n.type === 'mermaid');
+    expect(mermaidNodes).toHaveLength(2);
+
+    // ── SVG converter produced images keyed by the same IDs
+    expect(images.size).toBe(2);
+    expect(images.has('mermaid-arch1')).toBe(true);
+    expect(images.has('mermaid-seq1')).toBe(true);
+
+    // ── DOCX blob is non-trivial (contains actual image data)
+    expect(blob.size).toBeGreaterThan(1000);
+
+    // ── document.xml references images (w:drawing elements for ImageRun)
+    const drawingCount = countOccurrences(xml, '<w:drawing>');
+    expect(drawingCount).toBe(2);
+
+    container.remove();
+  });
+
+  it('should produce an empty diagram slot when SVG query misses mermaid containers', async () => {
+    // This simulates the OLD bug: querying 'svg' instead of '.mermaid-container svg'
+    // would pick up non-mermaid SVGs and miss the ID match in DOCXGenerator.
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <h1>Doc</h1>
+      <div class="mermaid-container mermaid-ready" id="mermaid-dia1">
+        <div class="mermaid-rendered">
+          <svg width="200" height="100" viewBox="0 0 200 100" xmlns="http://www.w3.org/2000/svg">
+            <rect width="200" height="100" fill="white"/>
+          </svg>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(container);
+
+    const collector = new ContentCollector();
+    const content = collector.collect(container);
+    expect(content.nodes.filter((n) => n.type === 'mermaid')).toHaveLength(1);
+
+    // ── CORRECT query: .mermaid-container svg → ID matches
+    const correctSvgs = Array.from(
+      container.querySelectorAll<SVGElement>('.mermaid-container svg')
+    );
+    const converter = new SVGConverter();
+    const correctImages = converter.convertAll(correctSvgs);
+    expect(correctImages.has('mermaid-dia1')).toBe(true);
+
+    const generator = new DOCXGenerator();
+    const goodBlob = await generator.generate(content, correctImages);
+    const goodXml = await extractDocumentXml(goodBlob);
+    expect(countOccurrences(goodXml, '<w:drawing>')).toBe(1);
+
+    // ── WRONG query (old bug): passing an empty images map → diagram is silently dropped
+    const emptyImages = new Map<string, never>();
+    const badBlob = await generator.generate(content, emptyImages);
+    const badXml = await extractDocumentXml(badBlob);
+    expect(countOccurrences(badXml, '<w:drawing>')).toBe(0);
+
+    // ── The correct approach must produce a larger file than the broken one
+    expect(goodBlob.size).toBeGreaterThan(badBlob.size);
+
+    container.remove();
+  });
+
+  it('should include mermaid diagrams nested inside progressive hydration sections', async () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+        <h1>Title</h1>
+        <p>Intro text.</p>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+        <h2>Diagram Section</h2>
+        <div class="mermaid-container mermaid-ready" id="mermaid-nested">
+          <div class="mermaid-rendered">
+            <svg width="500" height="250" viewBox="0 0 500 250" xmlns="http://www.w3.org/2000/svg">
+              <rect width="500" height="250" fill="#fafafa"/>
+            </svg>
+          </div>
+        </div>
+        <p>Description after diagram.</p>
+      </div>
+    `;
+    document.body.appendChild(container);
+
+    const { xml, content, images } = await exportContainer(container);
+
+    // collector found the diagram inside the section wrapper
+    expect(content.nodes.filter((n) => n.type === 'mermaid')).toHaveLength(1);
+
+    // converter mapped it by container ID
+    expect(images.has('mermaid-nested')).toBe(true);
+
+    // DOCX contains the image
+    expect(countOccurrences(xml, '<w:drawing>')).toBe(1);
+
+    container.remove();
+  });
+});
+
+describe('DOCX export integration — large document content', () => {
+  it('should export all paragraphs from progressive hydration sections, not just headings', async () => {
+    // This is the exact scenario that was broken: a large doc split into
+    // mdreview-section divs where each section has a heading + multiple paragraphs.
+    // The old bug caused processContainer() to return null for multi-child divs,
+    // so only sections with a single heading child survived.
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+        <h1>Introduction</h1>
+        <p>This is the opening paragraph of a large design document.</p>
+        <p>It contains multiple paragraphs of important content.</p>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+        <h2>Requirements</h2>
+        <p>The system must handle 10k requests per second.</p>
+        <p>Latency must stay below 50ms at p99.</p>
+        <ul><li>Scalability</li><li>Reliability</li><li>Observability</li></ul>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-2" data-hydrated="true">
+        <h2>Implementation</h2>
+        <p>We will use a microservices architecture.</p>
+        <pre><code class="language-go">func main() { http.ListenAndServe(":8080", nil) }</code></pre>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-3" data-hydrated="true">
+        <h2>Timeline</h2>
+        <table>
+          <thead><tr><th>Phase</th><th>Duration</th></tr></thead>
+          <tbody>
+            <tr><td>Design</td><td>2 weeks</td></tr>
+            <tr><td>Build</td><td>4 weeks</td></tr>
+          </tbody>
+        </table>
+      </div>
+    `;
+    document.body.appendChild(container);
+
+    const { xml, content } = await exportContainer(container);
+
+    // ── Must have all 4 headings
+    const headings = content.nodes.filter((n) => n.type === 'heading');
+    expect(headings).toHaveLength(4);
+
+    // ── Must have paragraphs (this is what the old bug dropped)
+    const paragraphs = content.nodes.filter((n) => n.type === 'paragraph');
+    expect(paragraphs.length).toBeGreaterThanOrEqual(5);
+
+    // ── Must have the list
+    const lists = content.nodes.filter((n) => n.type === 'list');
+    expect(lists).toHaveLength(1);
+
+    // ── Must have the code block
+    const codeBlocks = content.nodes.filter((n) => n.type === 'code');
+    expect(codeBlocks).toHaveLength(1);
+
+    // ── Must have the table
+    const tables = content.nodes.filter((n) => n.type === 'table');
+    expect(tables).toHaveLength(1);
+
+    // ── The DOCX XML must contain paragraph text, not just headings
+    expect(xml).toContain('10k requests per second');
+    expect(xml).toContain('microservices architecture');
+    expect(xml).toContain('Scalability');
+    expect(xml).toContain('Design');
+
+    // ── Sanity: blob is big enough to contain real content
+    expect(content.metadata.wordCount).toBeGreaterThan(20);
+
+    container.remove();
+  });
+
+  it('should export content from 10+ sections without dropping any', async () => {
+    const container = document.createElement('div');
+    const sectionCount = 12;
+
+    let html = '';
+    for (let i = 0; i < sectionCount; i++) {
+      html += `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-${i}" data-hydrated="true">
+          <h2>Section ${i}</h2>
+          <p>Content for section ${i} with unique marker SECT${i}MARKER.</p>
+        </div>
+      `;
+    }
+    container.innerHTML = html;
+    document.body.appendChild(container);
+
+    const { xml, content } = await exportContainer(container);
+
+    // ── All headings present
+    const headings = content.nodes.filter((n) => n.type === 'heading');
+    expect(headings).toHaveLength(sectionCount);
+
+    // ── All paragraphs present (one per section)
+    const paragraphs = content.nodes.filter((n) => n.type === 'paragraph');
+    expect(paragraphs).toHaveLength(sectionCount);
+
+    // ── Every section's content appears in the DOCX XML
+    for (let i = 0; i < sectionCount; i++) {
+      expect(xml).toContain(`SECT${i}MARKER`);
+    }
+
+    container.remove();
+  });
+
+  it('should export a mixed document with sections, diagrams, code, and tables', async () => {
+    // Realistic large document with all element types
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+        <h1>System Design</h1>
+        <p>Overview of the architecture.</p>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+        <h2>Architecture</h2>
+        <p>The system uses event-driven microservices.</p>
+        <div class="mermaid-container mermaid-ready" id="mermaid-arch">
+          <div class="mermaid-rendered">
+            <svg width="600" height="300" viewBox="0 0 600 300" xmlns="http://www.w3.org/2000/svg">
+              <rect width="600" height="300" fill="white"/>
+              <text x="300" y="150" text-anchor="middle">Architecture</text>
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-2" data-hydrated="true">
+        <h2>API</h2>
+        <div class="code-block-wrapper" data-language="typescript">
+          <pre><code class="language-typescript">app.get('/health', (req, res) => res.json({ ok: true }));</code></pre>
+        </div>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-3" data-hydrated="true">
+        <h2>Data Flow</h2>
+        <div class="mermaid-container mermaid-ready" id="mermaid-flow">
+          <div class="mermaid-rendered">
+            <svg width="400" height="200" viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg">
+              <rect width="400" height="200" fill="white"/>
+              <text x="200" y="100" text-anchor="middle">Flow</text>
+            </svg>
+          </div>
+        </div>
+        <p>Data flows from ingestion to storage.</p>
+      </div>
+      <div class="mdreview-section mdreview-section-hydrated" id="section-4" data-hydrated="true">
+        <h2>SLOs</h2>
+        <div class="table-wrapper">
+          <table>
+            <thead><tr><th>Metric</th><th>Target</th></tr></thead>
+            <tbody>
+              <tr><td>Availability</td><td>99.9%</td></tr>
+              <tr><td>Latency p99</td><td>50ms</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(container);
+
+    const { xml, content, images } = await exportContainer(container);
+
+    // headings
+    expect(content.nodes.filter((n) => n.type === 'heading')).toHaveLength(5);
+
+    // paragraphs (not dropped!)
+    expect(content.nodes.filter((n) => n.type === 'paragraph').length).toBeGreaterThanOrEqual(3);
+
+    // mermaid diagrams collected AND converted
+    expect(content.nodes.filter((n) => n.type === 'mermaid')).toHaveLength(2);
+    expect(images.size).toBe(2);
+    expect(images.has('mermaid-arch')).toBe(true);
+    expect(images.has('mermaid-flow')).toBe(true);
+
+    // DOCX contains both diagram images
+    expect(countOccurrences(xml, '<w:drawing>')).toBe(2);
+
+    // code block
+    expect(content.nodes.filter((n) => n.type === 'code')).toHaveLength(1);
+    expect(xml).toContain('health');
+
+    // table (unwrapped from table-wrapper)
+    expect(content.nodes.filter((n) => n.type === 'table')).toHaveLength(1);
+    expect(xml).toContain('Availability');
+    expect(xml).toContain('99.9%');
+
+    container.remove();
+  });
+});

--- a/packages/core/src/__tests__/export-controller.test.ts
+++ b/packages/core/src/__tests__/export-controller.test.ts
@@ -1,0 +1,223 @@
+/**
+ * ExportController regression tests
+ *
+ * Guards against:
+ * - Mermaid diagrams not being force-rendered before export
+ * - Wrong SVG query selector missing mermaid diagrams
+ * - Content from progressive hydration sections being dropped
+ * - Export pipeline silently swallowing errors
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the mermaid renderer so renderAllImmediate is observable
+const mockRenderAllImmediate = vi.fn().mockResolvedValue(undefined);
+vi.mock('../renderers/mermaid-renderer', () => ({
+  mermaidRenderer: {
+    renderAllImmediate: mockRenderAllImmediate,
+  },
+}));
+
+// Mock DOCXGenerator to avoid @jamesainslie/docx dependency in unit tests
+vi.mock('../utils/docx-generator', () => ({
+  DOCXGenerator: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.generate = vi
+      .fn()
+      .mockResolvedValue(new Blob(['mock-docx'], { type: 'application/octet-stream' }));
+  }),
+}));
+
+import { ExportController } from '../export-controller';
+import { ContentCollector } from '../utils/content-collector';
+import { SVGConverter } from '../utils/svg-converter';
+
+describe('ExportController', () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    container.id = 'mdreview-container';
+    document.body.innerHTML = '';
+    document.body.appendChild(container);
+  });
+
+  describe('mermaid force-rendering before export', () => {
+    it('should call renderAllImmediate when mermaid containers exist', async () => {
+      container.innerHTML = `
+        <h1>Title</h1>
+        <p>Content</p>
+        <div class="mermaid-container mermaid-ready" id="mermaid-test1">
+          <div class="mermaid-rendered">
+            <svg width="200" height="100" viewBox="0 0 200 100"></svg>
+          </div>
+        </div>
+      `;
+
+      const controller = new ExportController();
+      // Stub downloadBlob to prevent actual download
+      (controller as unknown as Record<string, unknown>)['downloadBlob'] = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await controller.export(container, { format: 'docx', filename: 'test' });
+
+      expect(mockRenderAllImmediate).toHaveBeenCalledWith(container);
+    });
+
+    it('should skip renderAllImmediate when no mermaid containers exist', async () => {
+      container.innerHTML = `
+        <h1>Title</h1>
+        <p>Just text, no diagrams.</p>
+      `;
+
+      const controller = new ExportController();
+      (controller as unknown as Record<string, unknown>)['downloadBlob'] = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await controller.export(container, { format: 'docx', filename: 'test' });
+
+      expect(mockRenderAllImmediate).not.toHaveBeenCalled();
+    });
+
+    it('should still export even if renderAllImmediate throws', async () => {
+      mockRenderAllImmediate.mockRejectedValueOnce(new Error('mermaid init failed'));
+
+      container.innerHTML = `
+        <h1>Title</h1>
+        <div class="mermaid-container mermaid-pending" id="mermaid-broken">
+          <div class="mermaid-loading">Loading...</div>
+        </div>
+      `;
+
+      const controller = new ExportController();
+      (controller as unknown as Record<string, unknown>)['downloadBlob'] = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      // Should not throw — the error is caught and export continues
+      await expect(
+        controller.export(container, { format: 'docx', filename: 'test' })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('SVG query selector', () => {
+    it('should only query SVGs inside .mermaid-container, not all SVGs', async () => {
+      container.innerHTML = `
+        <h1>Title</h1>
+        <div class="mermaid-container mermaid-ready" id="mermaid-dia1">
+          <div class="mermaid-rendered">
+            <svg width="200" height="100" id="mermaid-svg-1" viewBox="0 0 200 100">
+              <rect width="200" height="100" fill="white"/>
+            </svg>
+          </div>
+        </div>
+        <p>Some text with an icon <svg width="16" height="16" id="icon-svg"><circle r="8"/></svg></p>
+      `;
+
+      const convertAllSpy = vi.spyOn(SVGConverter.prototype, 'convertAll');
+
+      const controller = new ExportController();
+      (controller as unknown as Record<string, unknown>)['downloadBlob'] = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await controller.export(container, { format: 'docx', filename: 'test' });
+
+      // The SVGs passed to convertAll should only be mermaid SVGs
+      const svgsArg = convertAllSpy.mock.calls[0][0];
+      expect(svgsArg).toHaveLength(1);
+      expect(svgsArg[0].id).toBe('mermaid-svg-1');
+
+      convertAllSpy.mockRestore();
+    });
+  });
+
+  describe('progressive hydration section content', () => {
+    it('should collect all content from section wrappers in a full export flow', async () => {
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+          <h1 id="title">Architecture</h1>
+          <p>This system uses microservices.</p>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+          <h2 id="components">Components</h2>
+          <p>API Gateway handles routing.</p>
+          <p>Auth service validates tokens.</p>
+          <ul><li>Gateway</li><li>Auth</li><li>Data</li></ul>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-2" data-hydrated="true">
+          <h2 id="diagrams">Diagrams</h2>
+          <div class="mermaid-container mermaid-ready" id="mermaid-arch">
+            <div class="mermaid-rendered">
+              <svg width="400" height="200" viewBox="0 0 400 200">
+                <rect width="400" height="200" fill="white"/>
+              </svg>
+            </div>
+          </div>
+        </div>
+      `;
+
+      const collectSpy = vi.spyOn(ContentCollector.prototype, 'collect');
+
+      const controller = new ExportController();
+      (controller as unknown as Record<string, unknown>)['downloadBlob'] = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await controller.export(container, { format: 'docx', filename: 'test' });
+
+      interface ContentNode {
+        type: string;
+        attributes: Record<string, string>;
+      }
+      interface CollectedContent {
+        nodes: ContentNode[];
+      }
+      const collectedContent = collectSpy.mock.results[0]?.value as CollectedContent;
+
+      // Must have headings
+      const headings = collectedContent.nodes.filter((n) => n.type === 'heading');
+      expect(headings).toHaveLength(3);
+
+      // Must have paragraphs (the actual content, not just headings!)
+      const paragraphs = collectedContent.nodes.filter((n) => n.type === 'paragraph');
+      expect(paragraphs.length).toBeGreaterThanOrEqual(3);
+
+      // Must have the list
+      const lists = collectedContent.nodes.filter((n) => n.type === 'list');
+      expect(lists).toHaveLength(1);
+
+      // Must have the mermaid diagram
+      const mermaids = collectedContent.nodes.filter((n) => n.type === 'mermaid');
+      expect(mermaids).toHaveLength(1);
+      expect(mermaids[0].attributes.id).toBe('mermaid-arch');
+
+      collectSpy.mockRestore();
+    });
+  });
+
+  describe('progress reporting', () => {
+    it('should report progress through all stages', async () => {
+      container.innerHTML = '<h1>Simple Doc</h1><p>Content.</p>';
+
+      const stages: string[] = [];
+      const controller = new ExportController();
+      (controller as unknown as Record<string, unknown>)['downloadBlob'] = vi
+        .fn()
+        .mockResolvedValue(undefined);
+
+      await controller.export(container, { format: 'docx', filename: 'test' }, (progress) => {
+        if (!stages.includes(progress.stage)) {
+          stages.push(progress.stage);
+        }
+      });
+
+      expect(stages).toContain('collecting');
+      expect(stages).toContain('converting');
+      expect(stages).toContain('generating');
+      expect(stages).toContain('downloading');
+    });
+  });
+});

--- a/packages/core/src/__tests__/export-regression.test.ts
+++ b/packages/core/src/__tests__/export-regression.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Regression tests for export bugs:
+ * 1. Mermaid diagrams missing from DOCX export
+ * 2. Extension only exporting headers for large docs (progressive hydration sections)
+ * 3. Content collector dropping multi-child div contents
+ * 4. SVGConverter→DOCXGenerator ID mismatch causing blank diagrams
+ */
+import { describe, it, expect } from 'vitest';
+import { ContentCollector } from '../utils/content-collector';
+import { SVGConverter } from '../utils/svg-converter';
+
+describe('ContentCollector export regressions', () => {
+  describe('mermaid diagrams inside section wrappers', () => {
+    it('should collect mermaid nodes inside mdreview-section divs', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+          <h1 id="title">Title</h1>
+          <p>Introduction paragraph.</p>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+          <h2 id="architecture">Architecture</h2>
+          <p>Here is a diagram:</p>
+          <div class="mermaid-container mermaid-ready" id="mermaid-abc123" data-mermaid-code="graph TD; A-->B">
+            <div class="mermaid-rendered">
+              <svg width="200" height="100" viewBox="0 0 200 100"></svg>
+            </div>
+          </div>
+          <p>After the diagram.</p>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      const mermaidNodes = result.nodes.filter((n) => n.type === 'mermaid');
+      expect(mermaidNodes).toHaveLength(1);
+      expect(mermaidNodes[0].attributes.id).toBe('mermaid-abc123');
+    });
+
+    it('should collect mermaid nodes at top level (non-progressive)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <h1 id="title">Title</h1>
+        <p>Introduction.</p>
+        <div class="mermaid-container mermaid-ready" id="mermaid-xyz789" data-mermaid-code="graph LR; X-->Y">
+          <div class="mermaid-rendered">
+            <svg width="300" height="150" viewBox="0 0 300 150"></svg>
+          </div>
+        </div>
+        <p>After diagram.</p>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      const mermaidNodes = result.nodes.filter((n) => n.type === 'mermaid');
+      expect(mermaidNodes).toHaveLength(1);
+      expect(mermaidNodes[0].attributes.id).toBe('mermaid-xyz789');
+      expect(mermaidNodes[0].attributes.width).toBe('300');
+      expect(mermaidNodes[0].attributes.height).toBe('150');
+    });
+
+    it('should collect multiple mermaid diagrams across multiple sections', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+          <h1 id="title">Design Doc</h1>
+          <div class="mermaid-container mermaid-ready" id="mermaid-flow1" data-mermaid-code="graph TD; A-->B">
+            <div class="mermaid-rendered">
+              <svg width="200" height="100" viewBox="0 0 200 100"></svg>
+            </div>
+          </div>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+          <h2 id="sequence">Sequence</h2>
+          <div class="mermaid-container mermaid-ready" id="mermaid-seq1" data-mermaid-code="sequenceDiagram">
+            <div class="mermaid-rendered">
+              <svg width="400" height="300" viewBox="0 0 400 300"></svg>
+            </div>
+          </div>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-2" data-hydrated="true">
+          <h2 id="state">State</h2>
+          <p>State transitions:</p>
+          <div class="mermaid-container mermaid-ready" id="mermaid-state1" data-mermaid-code="stateDiagram-v2">
+            <div class="mermaid-rendered">
+              <svg width="350" height="250" viewBox="0 0 350 250"></svg>
+            </div>
+          </div>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      const mermaidNodes = result.nodes.filter((n) => n.type === 'mermaid');
+      expect(mermaidNodes).toHaveLength(3);
+      expect(mermaidNodes.map((n) => n.attributes.id)).toEqual([
+        'mermaid-flow1',
+        'mermaid-seq1',
+        'mermaid-state1',
+      ]);
+    });
+  });
+
+  describe('full content from progressive hydration sections', () => {
+    it('should collect all content from section wrapper divs (not just headings)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+          <h1 id="title">Document Title</h1>
+          <p>This is the introduction paragraph with important content.</p>
+          <p>This is a second paragraph.</p>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+          <h2 id="details">Details</h2>
+          <p>Detail paragraph one.</p>
+          <p>Detail paragraph two.</p>
+          <ul><li>Item one</li><li>Item two</li></ul>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-2" data-hydrated="true">
+          <h2 id="code-section">Code Section</h2>
+          <div class="code-block-wrapper" data-language="typescript">
+            <pre><code class="language-typescript">const x = 1;</code></pre>
+          </div>
+          <div class="table-wrapper">
+            <table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>
+          </div>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      // Should have headings
+      const headings = result.nodes.filter((n) => n.type === 'heading');
+      expect(headings).toHaveLength(3);
+
+      // Should have paragraphs (not just headings!)
+      const paragraphs = result.nodes.filter((n) => n.type === 'paragraph');
+      expect(paragraphs.length).toBeGreaterThanOrEqual(4);
+
+      // Should have list
+      const lists = result.nodes.filter((n) => n.type === 'list');
+      expect(lists).toHaveLength(1);
+
+      // Should have code block (unwrapped from code-block-wrapper)
+      const codeBlocks = result.nodes.filter((n) => n.type === 'code');
+      expect(codeBlocks).toHaveLength(1);
+      expect(codeBlocks[0].content).toContain('const x = 1');
+
+      // Should have table (unwrapped from table-wrapper)
+      const tables = result.nodes.filter((n) => n.type === 'table');
+      expect(tables).toHaveLength(1);
+    });
+
+    it('should not lose content from unhydrated skeleton sections', () => {
+      // Simulate a skeleton that was NOT hydrated (still has placeholder)
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-skeleton" id="section-0" data-hydrated="false" style="min-height: 300px;">
+          <h2 class="section-heading">Section Title</h2>
+          <div class="section-placeholder">
+            <div class="placeholder-shimmer"></div>
+          </div>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      // Should still collect the heading
+      const headings = result.nodes.filter((n) => n.type === 'heading');
+      expect(headings).toHaveLength(1);
+      expect(headings[0].content).toBe('Section Title');
+    });
+
+    it('should handle deeply nested section content (blockquotes, nested lists)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+          <h2 id="quotes">Quotes</h2>
+          <blockquote><p>This is a blockquote.</p></blockquote>
+          <ul>
+            <li>Top level item
+              <ul>
+                <li>Nested item</li>
+              </ul>
+            </li>
+          </ul>
+          <hr>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      const headings = result.nodes.filter((n) => n.type === 'heading');
+      expect(headings).toHaveLength(1);
+
+      const blockquotes = result.nodes.filter((n) => n.type === 'blockquote');
+      expect(blockquotes).toHaveLength(1);
+
+      const lists = result.nodes.filter((n) => n.type === 'list');
+      expect(lists).toHaveLength(1);
+
+      const hrs = result.nodes.filter((n) => n.type === 'hr');
+      expect(hrs).toHaveLength(1);
+    });
+
+    it('should handle mixed hydrated and unhydrated sections', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+          <h1 id="intro">Introduction</h1>
+          <p>This section is fully hydrated with real content.</p>
+        </div>
+        <div class="mdreview-section mdreview-section-skeleton" id="section-1" data-hydrated="false">
+          <h2 class="section-heading">Details</h2>
+          <div class="section-placeholder"><div class="placeholder-shimmer"></div></div>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-2" data-hydrated="true">
+          <h2 id="conclusion">Conclusion</h2>
+          <p>Final thoughts here.</p>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      const headings = result.nodes.filter((n) => n.type === 'heading');
+      expect(headings).toHaveLength(3);
+
+      // Hydrated sections should contribute paragraphs
+      const paragraphs = result.nodes.filter((n) => n.type === 'paragraph');
+      expect(paragraphs.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should preserve node order matching document order', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section mdreview-section-hydrated" id="section-0" data-hydrated="true">
+          <h1 id="title">Title</h1>
+          <p>Intro</p>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-1" data-hydrated="true">
+          <h2 id="mid">Middle</h2>
+          <p>Body</p>
+        </div>
+        <div class="mdreview-section mdreview-section-hydrated" id="section-2" data-hydrated="true">
+          <h2 id="end">End</h2>
+          <p>Conclusion</p>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      const types = result.nodes.map(
+        (n) => `${n.type}:${typeof n.content === 'string' ? n.content : ''}`
+      );
+      expect(types).toEqual([
+        'heading:Title',
+        'paragraph:Intro',
+        'heading:Middle',
+        'paragraph:Body',
+        'heading:End',
+        'paragraph:Conclusion',
+      ]);
+    });
+  });
+
+  describe('multi-child div regression (commit 6665cdd)', () => {
+    it('should not return null for divs with multiple children', () => {
+      // This was the exact bug: processContainer returned null
+      // when a div had more than one child element
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mdreview-section" id="section-0">
+          <h2>Heading</h2>
+          <p>First paragraph.</p>
+          <p>Second paragraph.</p>
+          <p>Third paragraph.</p>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      // Must have all 4 elements, not just the heading
+      expect(result.nodes).toHaveLength(4);
+      expect(result.nodes[0].type).toBe('heading');
+      expect(result.nodes[1].type).toBe('paragraph');
+      expect(result.nodes[2].type).toBe('paragraph');
+      expect(result.nodes[3].type).toBe('paragraph');
+    });
+
+    it('should flatten nested generic divs correctly', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div>
+          <div>
+            <h1>Deep Heading</h1>
+            <p>Deep paragraph.</p>
+          </div>
+        </div>
+      `;
+
+      const collector = new ContentCollector();
+      const result = collector.collect(container);
+
+      expect(result.nodes.length).toBeGreaterThanOrEqual(2);
+      const heading = result.nodes.find((n) => n.type === 'heading');
+      expect(heading).toBeDefined();
+      expect(heading!.content).toBe('Deep Heading');
+    });
+  });
+
+  describe('ContentCollector + SVGConverter ID agreement', () => {
+    it('should produce matching IDs between collector mermaid nodes and converter images', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <h1>Doc</h1>
+        <div class="mermaid-container mermaid-ready" id="mermaid-abc">
+          <div class="mermaid-rendered">
+            <svg width="200" height="100" viewBox="0 0 200 100" id="mermaid-svg-abc">
+              <rect width="200" height="100" fill="white"/>
+            </svg>
+          </div>
+        </div>
+        <div class="mermaid-container mermaid-ready" id="mermaid-def">
+          <div class="mermaid-rendered">
+            <svg width="300" height="150" viewBox="0 0 300 150" id="mermaid-svg-def">
+              <rect width="300" height="150" fill="white"/>
+            </svg>
+          </div>
+        </div>
+      `;
+      document.body.appendChild(container);
+
+      // Step 1: Collect content (as ExportController does)
+      const collector = new ContentCollector();
+      const content = collector.collect(container);
+
+      // Step 2: Query mermaid SVGs (as ExportController does)
+      const svgElements = Array.from(
+        container.querySelectorAll<SVGElement>('.mermaid-container svg')
+      );
+
+      // Step 3: Convert SVGs (as ExportController does)
+      const converter = new SVGConverter();
+      const images = converter.convertAll(svgElements);
+
+      // Verify: every mermaid node ID from the collector has a matching image
+      const mermaidNodes = content.nodes.filter((n) => n.type === 'mermaid');
+      expect(mermaidNodes).toHaveLength(2);
+
+      for (const node of mermaidNodes) {
+        const id = node.attributes.id as string;
+        expect(images.has(id)).toBe(true);
+        expect(images.get(id)!.format).toBe('svg');
+        expect(images.get(id)!.width).toBeGreaterThan(0);
+      }
+
+      container.remove();
+    });
+
+    it('should NOT match when using generic svg query (demonstrates the old bug)', () => {
+      const container = document.createElement('div');
+      container.innerHTML = `
+        <div class="mermaid-container mermaid-ready" id="mermaid-only">
+          <div class="mermaid-rendered">
+            <svg width="200" height="100" viewBox="0 0 200 100">
+              <rect width="200" height="100" fill="white"/>
+            </svg>
+          </div>
+        </div>
+        <svg width="16" height="16" id="unrelated-icon"><circle r="8"/></svg>
+      `;
+      document.body.appendChild(container);
+
+      // The correct query: only mermaid SVGs
+      const mermaidSvgs = Array.from(
+        container.querySelectorAll<SVGElement>('.mermaid-container svg')
+      );
+      expect(mermaidSvgs).toHaveLength(1);
+
+      // The old buggy query: ALL svgs
+      const allSvgs = Array.from(container.querySelectorAll<SVGElement>('svg'));
+      expect(allSvgs).toHaveLength(2); // Would include the icon
+
+      container.remove();
+    });
+  });
+});

--- a/packages/core/src/__tests__/svg-converter.test.ts
+++ b/packages/core/src/__tests__/svg-converter.test.ts
@@ -1,0 +1,236 @@
+/**
+ * SVGConverter regression tests
+ *
+ * Guards against:
+ * - Mermaid container ID not matching ContentCollector's mermaid node IDs
+ * - Dimension extraction failures
+ * - foreignObject conversion breaking diagram text
+ * - convertAll silently dropping diagrams on error
+ */
+import { describe, it, expect } from 'vitest';
+import { SVGConverter } from '../utils/svg-converter';
+
+/**
+ * Helper: create a minimal SVG element inside an optional mermaid container.
+ * Returns the SVG (which is what SVGConverter.convert() receives).
+ */
+function createMermaidSvg(
+  containerId: string,
+  opts: { width?: number; height?: number; svgId?: string } = {}
+): { svg: SVGElement; container: HTMLDivElement } {
+  const { width = 200, height = 100, svgId } = opts;
+  const container = document.createElement('div');
+  container.className = 'mermaid-container mermaid-ready';
+  container.id = containerId;
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'mermaid-rendered';
+  container.appendChild(wrapper);
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.setAttribute('width', String(width));
+  svg.setAttribute('height', String(height));
+  svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+  if (svgId) svg.id = svgId;
+  wrapper.appendChild(svg);
+
+  // Must be in the document for closest() to work
+  document.body.appendChild(container);
+
+  return { svg, container };
+}
+
+function createStandaloneSvg(
+  id: string,
+  opts: { width?: number; height?: number } = {}
+): SVGElement {
+  const { width = 16, height = 16 } = opts;
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.id = id;
+  svg.setAttribute('width', String(width));
+  svg.setAttribute('height', String(height));
+  document.body.appendChild(svg);
+  return svg;
+}
+
+describe('SVGConverter', () => {
+  describe('mermaid container ID matching', () => {
+    it('should use the mermaid container ID, not the SVG element ID', () => {
+      const { svg, container } = createMermaidSvg('mermaid-abc123', {
+        svgId: 'mermaid-svg-inner',
+      });
+
+      const converter = new SVGConverter();
+      const result = converter.convert(svg);
+
+      expect(result.id).toBe('mermaid-abc123');
+      container.remove();
+    });
+
+    it('should fall back to SVG id when not inside a mermaid container', () => {
+      const svg = createStandaloneSvg('standalone-icon');
+
+      const converter = new SVGConverter();
+      const result = converter.convert(svg);
+
+      expect(result.id).toBe('standalone-icon');
+      svg.remove();
+    });
+
+    it('should generate a fallback ID when neither container nor SVG has one', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('width', '50');
+      svg.setAttribute('height', '50');
+      document.body.appendChild(svg);
+
+      const converter = new SVGConverter();
+      const result = converter.convert(svg);
+
+      expect(result.id).toMatch(/^svg-\d+$/);
+      svg.remove();
+    });
+  });
+
+  describe('convertAll', () => {
+    it('should produce a Map keyed by mermaid container IDs', () => {
+      const { svg: svg1, container: c1 } = createMermaidSvg('mermaid-aaa', {
+        width: 300,
+        height: 200,
+      });
+      const { svg: svg2, container: c2 } = createMermaidSvg('mermaid-bbb', {
+        width: 400,
+        height: 250,
+      });
+
+      const converter = new SVGConverter();
+      const images = converter.convertAll([svg1, svg2]);
+
+      expect(images.size).toBe(2);
+      expect(images.has('mermaid-aaa')).toBe(true);
+      expect(images.has('mermaid-bbb')).toBe(true);
+      expect(images.get('mermaid-aaa')!.width).toBe(300);
+      expect(images.get('mermaid-bbb')!.width).toBe(400);
+
+      c1.remove();
+      c2.remove();
+    });
+
+    it('should skip failing SVGs and still convert the rest', () => {
+      const { svg: goodSvg, container } = createMermaidSvg('mermaid-good', {
+        width: 100,
+        height: 50,
+      });
+
+      // Create an SVG that will fail serialization by detaching it
+      const badSvg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      // Override serializeToString to throw for this SVG
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const origSerialize = XMLSerializer.prototype.serializeToString;
+      let callCount = 0;
+      XMLSerializer.prototype.serializeToString = function (node) {
+        callCount++;
+        if (callCount === 1) throw new Error('Simulated failure');
+        return origSerialize.call(this, node);
+      };
+
+      const converter = new SVGConverter();
+      const images = converter.convertAll([badSvg, goodSvg]);
+
+      // Restore
+      XMLSerializer.prototype.serializeToString = origSerialize;
+
+      expect(images.size).toBe(1);
+      expect(images.has('mermaid-good')).toBe(true);
+
+      container.remove();
+    });
+  });
+
+  describe('dimension extraction', () => {
+    it('should read width/height attributes', () => {
+      const { svg, container } = createMermaidSvg('mermaid-dim1', { width: 500, height: 300 });
+
+      const converter = new SVGConverter();
+      const result = converter.convert(svg);
+
+      expect(result.width).toBe(500);
+      expect(result.height).toBe(300);
+      container.remove();
+    });
+
+    it('should fall back to viewBox when width/height missing', () => {
+      const container = document.createElement('div');
+      container.className = 'mermaid-container mermaid-ready';
+      container.id = 'mermaid-vb';
+      const wrapper = document.createElement('div');
+      wrapper.className = 'mermaid-rendered';
+      container.appendChild(wrapper);
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('viewBox', '0 0 800 400');
+      // No width/height attributes
+      wrapper.appendChild(svg);
+      document.body.appendChild(container);
+
+      const converter = new SVGConverter();
+      const result = converter.convert(svg);
+
+      expect(result.width).toBe(800);
+      expect(result.height).toBe(400);
+      container.remove();
+    });
+  });
+
+  describe('SVG output format', () => {
+    it('should produce base64-encoded SVG format', () => {
+      const { svg, container } = createMermaidSvg('mermaid-fmt', { width: 100, height: 50 });
+
+      const converter = new SVGConverter();
+      const result = converter.convert(svg);
+
+      expect(result.format).toBe('svg');
+      expect(result.data).toBeTruthy();
+      // Decode and verify it's valid SVG XML
+      const decoded = atob(result.data);
+      expect(decoded).toContain('<svg');
+      expect(decoded).toContain('xmlns="http://www.w3.org/2000/svg"');
+
+      container.remove();
+    });
+  });
+
+  describe('foreignObject conversion', () => {
+    it('should replace foreignObject elements with SVG text', () => {
+      const container = document.createElement('div');
+      container.className = 'mermaid-container mermaid-ready';
+      container.id = 'mermaid-fo';
+      const wrapper = document.createElement('div');
+      wrapper.className = 'mermaid-rendered';
+      container.appendChild(wrapper);
+
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('width', '200');
+      svg.setAttribute('height', '100');
+      svg.innerHTML = `
+        <foreignObject x="10" y="10" width="80" height="30">
+          <div xmlns="http://www.w3.org/1999/xhtml">
+            <span>Node Label</span>
+          </div>
+        </foreignObject>
+      `;
+      wrapper.appendChild(svg);
+      document.body.appendChild(container);
+
+      const converter = new SVGConverter();
+      const result = converter.convert(svg);
+
+      // foreignObject should have been replaced — the output SVG
+      // should contain text with "Node Label" but no foreignObject
+      const decoded = atob(result.data);
+      expect(decoded).not.toContain('foreignObject');
+      expect(decoded).toContain('Node Label');
+
+      container.remove();
+    });
+  });
+});

--- a/packages/electron/src/main/directory-service.test.ts
+++ b/packages/electron/src/main/directory-service.test.ts
@@ -28,11 +28,11 @@ describe('DirectoryService', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('should list markdown files in a directory', () => {
+  it('should list markdown files in a directory', async () => {
     writeFileSync(join(tmpDir, 'readme.md'), '# Hello');
     writeFileSync(join(tmpDir, 'notes.markdown'), '# Notes');
 
-    const entries = service.listDirectory(tmpDir);
+    const entries = await service.listDirectory(tmpDir);
     const names = entries.map((e) => e.name);
 
     expect(names).toContain('readme.md');
@@ -40,41 +40,39 @@ describe('DirectoryService', () => {
     expect(entries.every((e) => e.type === 'file')).toBe(true);
   });
 
-  it('should sort directories first, then alphabetically', () => {
+  it('should sort directories first, then alphabetically', async () => {
     mkdirSync(join(tmpDir, 'zebra'));
-    writeFileSync(join(tmpDir, 'zebra', 'file.md'), '# Z');
     mkdirSync(join(tmpDir, 'alpha'));
-    writeFileSync(join(tmpDir, 'alpha', 'file.md'), '# A');
     writeFileSync(join(tmpDir, 'beta.md'), '# B');
     writeFileSync(join(tmpDir, 'aaa.md'), '# A');
 
-    const entries = service.listDirectory(tmpDir);
+    const entries = await service.listDirectory(tmpDir);
     const names = entries.map((e) => e.name);
 
     // Directories first (alphabetically), then files (alphabetically)
     expect(names).toEqual(['alpha', 'zebra', 'aaa.md', 'beta.md']);
   });
 
-  it('should filter out non-markdown files', () => {
+  it('should filter out non-markdown files', async () => {
     writeFileSync(join(tmpDir, 'readme.md'), '# Hello');
     writeFileSync(join(tmpDir, 'image.png'), 'binary');
     writeFileSync(join(tmpDir, 'style.css'), 'body {}');
     writeFileSync(join(tmpDir, 'data.json'), '{}');
 
-    const entries = service.listDirectory(tmpDir);
+    const entries = await service.listDirectory(tmpDir);
 
     expect(entries).toHaveLength(1);
     expect(entries[0].name).toBe('readme.md');
   });
 
-  it('should build recursive tree structure', () => {
+  it('should list immediate children only', async () => {
     mkdirSync(join(tmpDir, 'docs'));
     writeFileSync(join(tmpDir, 'docs', 'guide.md'), '# Guide');
     mkdirSync(join(tmpDir, 'docs', 'api'));
     writeFileSync(join(tmpDir, 'docs', 'api', 'reference.md'), '# Ref');
     writeFileSync(join(tmpDir, 'readme.md'), '# Root');
 
-    const entries = service.listDirectory(tmpDir);
+    const entries = await service.listDirectory(tmpDir);
 
     // Should have docs/ directory and readme.md
     expect(entries).toHaveLength(2);
@@ -82,37 +80,83 @@ describe('DirectoryService', () => {
     const docsDir = entries.find((e) => e.name === 'docs');
     expect(docsDir).toBeDefined();
     expect(docsDir!.type).toBe('directory');
-    expect(docsDir!.children).toBeDefined();
-    expect(docsDir!.children).toHaveLength(2); // api/ and guide.md
+    // Shallow: children are undefined (not loaded yet)
+    expect(docsDir!.children).toBeUndefined();
+  });
 
-    const apiDir = docsDir!.children!.find((e) => e.name === 'api');
+  it('should support incremental loading via successive calls', async () => {
+    mkdirSync(join(tmpDir, 'docs'));
+    writeFileSync(join(tmpDir, 'docs', 'guide.md'), '# Guide');
+    mkdirSync(join(tmpDir, 'docs', 'api'));
+    writeFileSync(join(tmpDir, 'docs', 'api', 'reference.md'), '# Ref');
+    writeFileSync(join(tmpDir, 'readme.md'), '# Root');
+
+    // First call: root level
+    const rootEntries = await service.listDirectory(tmpDir);
+    expect(rootEntries).toHaveLength(2);
+    const docsDir = rootEntries.find((e) => e.name === 'docs');
+    expect(docsDir!.children).toBeUndefined();
+
+    // Second call: expand docs/
+    const docsEntries = await service.listDirectory(join(tmpDir, 'docs'));
+    expect(docsEntries).toHaveLength(2); // api/ and guide.md
+    const apiDir = docsEntries.find((e) => e.name === 'api');
     expect(apiDir).toBeDefined();
     expect(apiDir!.type).toBe('directory');
-    expect(apiDir!.children).toHaveLength(1);
-    expect(apiDir!.children![0].name).toBe('reference.md');
+    expect(apiDir!.children).toBeUndefined();
+    const guideFile = docsEntries.find((e) => e.name === 'guide.md');
+    expect(guideFile).toBeDefined();
+    expect(guideFile!.type).toBe('file');
   });
 
-  it('should handle empty directory', () => {
-    const entries = service.listDirectory(tmpDir);
+  it('should handle empty directory', async () => {
+    const entries = await service.listDirectory(tmpDir);
     expect(entries).toEqual([]);
   });
 
-  it('should handle nonexistent directory gracefully', () => {
-    const entries = service.listDirectory(join(tmpDir, 'nonexistent'));
+  it('should handle nonexistent directory gracefully', async () => {
+    const entries = await service.listDirectory(join(tmpDir, 'nonexistent'));
     expect(entries).toEqual([]);
   });
 
-  it('should exclude directories that contain no markdown files', () => {
+  it('should include all non-hidden, non-excluded directories', async () => {
     mkdirSync(join(tmpDir, 'images'));
     writeFileSync(join(tmpDir, 'images', 'photo.png'), 'binary');
     mkdirSync(join(tmpDir, 'docs'));
     writeFileSync(join(tmpDir, 'docs', 'guide.md'), '# Guide');
 
-    const entries = service.listDirectory(tmpDir);
+    const entries = await service.listDirectory(tmpDir);
 
     const names = entries.map((e) => e.name);
-    expect(names).not.toContain('images');
+    // With shallow loading, all dirs appear (we don't know contents yet)
+    expect(names).toContain('images');
     expect(names).toContain('docs');
+  });
+
+  it('should exclude hidden files and directories', async () => {
+    mkdirSync(join(tmpDir, '.git'));
+    writeFileSync(join(tmpDir, '.hidden'), 'secret');
+    writeFileSync(join(tmpDir, 'readme.md'), '# Hello');
+
+    const entries = await service.listDirectory(tmpDir);
+    const names = entries.map((e) => e.name);
+
+    expect(names).not.toContain('.git');
+    expect(names).not.toContain('.hidden');
+    expect(names).toContain('readme.md');
+  });
+
+  it('should exclude node_modules directory', async () => {
+    mkdirSync(join(tmpDir, 'node_modules'));
+    writeFileSync(join(tmpDir, 'node_modules', 'pkg.js'), 'module');
+    mkdirSync(join(tmpDir, 'src'));
+    writeFileSync(join(tmpDir, 'readme.md'), '# Hello');
+
+    const entries = await service.listDirectory(tmpDir);
+    const names = entries.map((e) => e.name);
+
+    expect(names).not.toContain('node_modules');
+    expect(names).toContain('src');
   });
 
   it('should watch and call back on changes', () => {
@@ -154,24 +198,24 @@ describe('DirectoryService', () => {
     expect(mockWatcher.close).toHaveBeenCalledTimes(1);
   });
 
-  it('should recognize all markdown extensions', () => {
+  it('should recognize all markdown extensions', async () => {
     const extensions = ['.md', '.markdown', '.mdown', '.mkd', '.mkdn', '.mdx'];
     for (const ext of extensions) {
       writeFileSync(join(tmpDir, `file${ext}`), '# Test');
     }
 
-    const entries = service.listDirectory(tmpDir);
+    const entries = await service.listDirectory(tmpDir);
     expect(entries).toHaveLength(extensions.length);
   });
 
   describe('showAllFiles option', () => {
-    it('should include non-markdown files when showAllFiles is true', () => {
+    it('should include non-markdown files when showAllFiles is true', async () => {
       writeFileSync(join(tmpDir, 'readme.md'), '# Hello');
       writeFileSync(join(tmpDir, 'image.png'), 'binary');
       writeFileSync(join(tmpDir, 'style.css'), 'body {}');
       writeFileSync(join(tmpDir, 'data.json'), '{}');
 
-      const entries = service.listDirectory(tmpDir, { showAllFiles: true });
+      const entries = await service.listDirectory(tmpDir, { showAllFiles: true });
 
       const names = entries.map((e) => e.name);
       expect(names).toContain('readme.md');
@@ -181,58 +225,53 @@ describe('DirectoryService', () => {
       expect(entries).toHaveLength(4);
     });
 
-    it('should still exclude hidden files when showAllFiles is true', () => {
+    it('should still exclude hidden files when showAllFiles is true', async () => {
       writeFileSync(join(tmpDir, '.hidden'), 'secret');
       writeFileSync(join(tmpDir, 'visible.txt'), 'hello');
 
-      const entries = service.listDirectory(tmpDir, { showAllFiles: true });
+      const entries = await service.listDirectory(tmpDir, { showAllFiles: true });
 
       const names = entries.map((e) => e.name);
       expect(names).not.toContain('.hidden');
       expect(names).toContain('visible.txt');
     });
 
-    it('should exclude node_modules directory when showAllFiles is true', () => {
+    it('should exclude node_modules directory when showAllFiles is true', async () => {
       mkdirSync(join(tmpDir, 'node_modules'));
       writeFileSync(join(tmpDir, 'node_modules', 'pkg.js'), 'module');
       mkdirSync(join(tmpDir, 'src'));
       writeFileSync(join(tmpDir, 'src', 'app.ts'), 'code');
 
-      const entries = service.listDirectory(tmpDir, { showAllFiles: true });
+      const entries = await service.listDirectory(tmpDir, { showAllFiles: true });
 
       const names = entries.map((e) => e.name);
       expect(names).not.toContain('node_modules');
       expect(names).toContain('src');
     });
 
-    it('should show directories that have non-markdown children when showAllFiles is true', () => {
+    it('should show all directories regardless of contents when showAllFiles is true', async () => {
       mkdirSync(join(tmpDir, 'images'));
       writeFileSync(join(tmpDir, 'images', 'photo.png'), 'binary');
 
-      // With default options, images dir is excluded
-      const defaultEntries = service.listDirectory(tmpDir);
-      expect(defaultEntries.map((e) => e.name)).not.toContain('images');
-
-      // With showAllFiles, images dir is included
-      const allEntries = service.listDirectory(tmpDir, { showAllFiles: true });
+      const allEntries = await service.listDirectory(tmpDir, { showAllFiles: true });
       expect(allEntries.map((e) => e.name)).toContain('images');
     });
 
-    it('should default to markdown-only when options not provided', () => {
+    it('should default to markdown-only when options not provided', async () => {
       writeFileSync(join(tmpDir, 'readme.md'), '# Hello');
       writeFileSync(join(tmpDir, 'image.png'), 'binary');
 
-      const entries = service.listDirectory(tmpDir);
+      const entries = await service.listDirectory(tmpDir);
 
       expect(entries).toHaveLength(1);
       expect(entries[0].name).toBe('readme.md');
     });
 
-    it('should default to markdown-only when showAllFiles is false', () => {
+    it('should default to markdown-only when showAllFiles is false', async () => {
       writeFileSync(join(tmpDir, 'readme.md'), '# Hello');
       writeFileSync(join(tmpDir, 'image.png'), 'binary');
 
-      const entries = service.listDirectory(tmpDir, { showAllFiles: false });
+      const entries = await service.listDirectory(tmpDir, { showAllFiles: false });
 
       expect(entries).toHaveLength(1);
       expect(entries[0].name).toBe('readme.md');

--- a/packages/electron/src/main/directory-service.ts
+++ b/packages/electron/src/main/directory-service.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync } from 'fs';
+import { readdir } from 'fs/promises';
 import { join, extname } from 'path';
 import { watch } from 'chokidar';
 import type { DirectoryEntry } from '../shared/workspace-types';
@@ -17,9 +17,9 @@ interface WatcherHandle {
 export class DirectoryService {
   private watchers = new Map<string, WatcherHandle>();
 
-  listDirectory(dirPath: string, options?: ListDirectoryOptions): DirectoryEntry[] {
+  async listDirectory(dirPath: string, options?: ListDirectoryOptions): Promise<DirectoryEntry[]> {
     try {
-      return this.readDirectoryRecursive(dirPath, options?.showAllFiles ?? false);
+      return await this.readDirectoryShallow(dirPath, options?.showAllFiles ?? false);
     } catch {
       return [];
     }
@@ -62,41 +62,32 @@ export class DirectoryService {
     this.watchers.clear();
   }
 
-  private readDirectoryRecursive(dirPath: string, showAllFiles: boolean): DirectoryEntry[] {
-    const rawEntries = readdirSync(dirPath);
+  private async readDirectoryShallow(
+    dirPath: string,
+    showAllFiles: boolean
+  ): Promise<DirectoryEntry[]> {
+    const dirents = await readdir(dirPath, { withFileTypes: true });
     const directories: DirectoryEntry[] = [];
     const files: DirectoryEntry[] = [];
 
-    for (const name of rawEntries) {
+    for (const dirent of dirents) {
       // Skip hidden files/directories
-      if (name.startsWith('.')) continue;
+      if (dirent.name.startsWith('.')) continue;
 
-      const fullPath = join(dirPath, name);
-      let stat;
-      try {
-        stat = statSync(fullPath);
-      } catch {
-        continue;
-      }
+      const fullPath = join(dirPath, dirent.name);
 
-      if (stat.isDirectory()) {
-        // Skip excluded directories
-        if (EXCLUDED_DIRS.has(name)) continue;
+      if (dirent.isDirectory()) {
+        if (EXCLUDED_DIRS.has(dirent.name)) continue;
 
-        const children = this.readDirectoryRecursive(fullPath, showAllFiles);
-        // Only include directories that have children (MD-only or all files depending on mode)
-        if (children.length > 0) {
-          directories.push({
-            name,
-            path: fullPath,
-            type: 'directory',
-            children,
-          });
-        }
-      } else if (stat.isFile()) {
-        if (showAllFiles || MD_EXTENSIONS.has(extname(name).toLowerCase())) {
+        directories.push({
+          name: dirent.name,
+          path: fullPath,
+          type: 'directory',
+        });
+      } else if (dirent.isFile()) {
+        if (showAllFiles || MD_EXTENSIONS.has(extname(dirent.name).toLowerCase())) {
           files.push({
-            name,
+            name: dirent.name,
             path: fullPath,
             type: 'file',
           });

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -33,6 +33,12 @@ const THEME_BACKGROUNDS: Record<string, string> = {
 // Set the app name for the Dock and menu bar (dev mode uses package.json name otherwise)
 app.setName('Design Review');
 
+app.setAboutPanelOptions({
+  applicationName: 'Design Review',
+  applicationVersion: app.getVersion(),
+  credits: 'built with ❤️ by James Ainslie',
+});
+
 // Register custom protocol for serving local assets (images, etc.)
 // Must be called before app.whenReady()
 protocol.registerSchemesAsPrivileged([

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app, BrowserWindow, dialog, protocol, net, nativeImage } from 'electron';
+import { readFile } from 'fs/promises';
 import { join, extname, basename } from 'path';
 import { pathToFileURL } from 'url';
 import ElectronStore from 'electron-store';
@@ -45,6 +46,16 @@ protocol.registerSchemesAsPrivileged([
   {
     scheme: 'local-asset',
     privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true },
+  },
+  {
+    scheme: 'app',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      codeCache: true,
+    },
   },
 ]);
 
@@ -94,7 +105,7 @@ function createWindow(backgroundColor?: string): BrowserWindow {
   if (process.env.ELECTRON_RENDERER_URL) {
     void win.loadURL(process.env.ELECTRON_RENDERER_URL);
   } else {
-    void win.loadFile(join(__dirname, '../renderer/index.html'));
+    void win.loadURL('app://renderer/index.html');
   }
 
   return win;
@@ -212,6 +223,34 @@ void app.whenReady().then(async () => {
     }
   });
 
+  // Handle app:// protocol — serves renderer files so the page runs under a
+  // secure, standard scheme instead of file://.  This enables web workers
+  // (Worker constructor requires a non-file: origin) and V8 code caching.
+  const APP_MIME_TYPES: Record<string, string> = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.woff2': 'font/woff2',
+  };
+
+  protocol.handle('app', async (request) => {
+    try {
+      const url = new URL(request.url);
+      const filePath = join(__dirname, '../renderer', decodeURIComponent(url.pathname));
+      const data = await readFile(filePath);
+      const ext = extname(filePath).toLowerCase();
+      return new Response(data, {
+        headers: { 'Content-Type': APP_MIME_TYPES[ext] || 'application/octet-stream' },
+      });
+    } catch (err) {
+      console.error('[mdreview] app:// protocol error:', request.url, err);
+      return new Response('Not Found', { status: 404 });
+    }
+  });
+
   openFilePath = parseOpenFilePath();
 
   const syncStore = new ElectronStore({ name: 'preferences' });
@@ -277,6 +316,8 @@ void app.whenReady().then(async () => {
   });
 
   mainWindow.on('close', () => {
+    // Flush any pending debounced state before saving session
+    stateManagerRef?.flushPersist();
     // Clean up watchers BEFORE the window is destroyed to prevent
     // callbacks firing on a destroyed webContents.
     saveSession();
@@ -290,6 +331,7 @@ void app.whenReady().then(async () => {
   });
 
   app.on('before-quit', () => {
+    stateManagerRef?.flushPersist();
     saveSession();
   });
 });

--- a/packages/electron/src/main/ipc-handlers.test.ts
+++ b/packages/electron/src/main/ipc-handlers.test.ts
@@ -16,6 +16,12 @@ vi.mock('electron', () => ({
   },
   shell: {
     openExternal: vi.fn().mockResolvedValue(undefined),
+    showItemInFolder: vi.fn(),
+  },
+  Menu: {
+    buildFromTemplate: vi.fn().mockReturnValue({
+      popup: vi.fn(),
+    }),
   },
 }));
 
@@ -119,6 +125,8 @@ describe('IPC Handlers', () => {
       IPC_CHANNELS.SET_SIDEBAR_WIDTH,
       IPC_CHANNELS.SET_OPEN_FOLDER,
       IPC_CHANNELS.OPEN_EXTERNAL,
+      IPC_CHANNELS.SHOW_CONTEXT_MENU,
+      IPC_CHANNELS.REVEAL_IN_FINDER,
       IPC_CHANNELS.LIST_DIRECTORY,
       IPC_CHANNELS.WATCH_DIRECTORY,
       IPC_CHANNELS.UNWATCH_DIRECTORY,
@@ -256,7 +264,7 @@ describe('IPC Handlers', () => {
 
   it('LIST_DIRECTORY should pass options to directoryService', async () => {
     const mockDirectoryService = {
-      listDirectory: vi.fn().mockReturnValue([]),
+      listDirectory: vi.fn().mockResolvedValue([]),
       watchDirectory: vi.fn(),
       unwatchDirectory: vi.fn(),
       dispose: vi.fn(),
@@ -266,7 +274,9 @@ describe('IPC Handlers', () => {
 
     const handler = handlers.get(IPC_CHANNELS.LIST_DIRECTORY);
     await handler?.({}, '/tmp/folder', { showAllFiles: true });
-    expect(mockDirectoryService.listDirectory).toHaveBeenCalledWith('/tmp/folder', { showAllFiles: true });
+    expect(mockDirectoryService.listDirectory).toHaveBeenCalledWith('/tmp/folder', {
+      showAllFiles: true,
+    });
   });
 
   it('UNWATCH_FILE should clean up watcher', async () => {
@@ -283,5 +293,153 @@ describe('IPC Handlers', () => {
     await unwatchHandler?.({}, '/tmp/test.md');
 
     expect(unwatchFn).toHaveBeenCalled();
+  });
+
+  describe('SHOW_CONTEXT_MENU', () => {
+    it('should build menu with selection items when text is selected', async () => {
+      const electron = await import('electron');
+      const handler = handlers.get(IPC_CHANNELS.SHOW_CONTEXT_MENU);
+      await handler?.(
+        {},
+        {
+          hasSelection: true,
+          selectionText: 'hello world',
+          filePath: '/tmp/test.md',
+        }
+      );
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(vi.mocked(electron.Menu.buildFromTemplate)).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ label: 'Copy', accelerator: 'CmdOrCtrl+C' }),
+          expect.objectContaining({ label: 'Leave a Comment' }),
+          expect.objectContaining({
+            label: expect.stringContaining('Look Up') as string,
+          }),
+          expect.objectContaining({ label: 'Search with Google' }),
+          expect.objectContaining({ label: 'Select All', accelerator: 'CmdOrCtrl+A' }),
+        ])
+      );
+    });
+
+    it('should build menu without selection items when no text is selected', async () => {
+      const electron = await import('electron');
+      const handler = handlers.get(IPC_CHANNELS.SHOW_CONTEXT_MENU);
+      await handler?.(
+        {},
+        {
+          hasSelection: false,
+          selectionText: '',
+          filePath: '/tmp/test.md',
+        }
+      );
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      const template = vi.mocked(electron.Menu.buildFromTemplate).mock.calls[0][0] as Array<{
+        label?: string;
+      }>;
+      const labels = template.filter((item) => item.label).map((item) => item.label);
+      expect(labels).toContain('Select All');
+      expect(labels).toContain('Copy File Path');
+      expect(labels).toContain('Reveal in Finder');
+      expect(labels).toContain('Reload');
+      expect(labels).not.toContain('Copy');
+      expect(labels).not.toContain('Leave a Comment');
+    });
+
+    it('should send context:copy command when Copy is clicked', async () => {
+      const electron = await import('electron');
+      const handler = handlers.get(IPC_CHANNELS.SHOW_CONTEXT_MENU);
+      await handler?.(
+        {},
+        {
+          hasSelection: true,
+          selectionText: 'test',
+          filePath: '/tmp/test.md',
+        }
+      );
+
+      const template = (electron.Menu.buildFromTemplate as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as Array<{ label?: string; click?: () => void }>;
+      const copyItem = template.find((item) => item.label === 'Copy');
+      copyItem?.click?.();
+
+      const mockWin = deps.getWindow() as { webContents: { send: ReturnType<typeof vi.fn> } };
+      expect(mockWin.webContents.send).toHaveBeenCalledWith(
+        IPC_CHANNELS.MENU_COMMAND,
+        'context:copy'
+      );
+    });
+
+    it('should send context:comment command when Leave a Comment is clicked', async () => {
+      const electron = await import('electron');
+      const handler = handlers.get(IPC_CHANNELS.SHOW_CONTEXT_MENU);
+      await handler?.(
+        {},
+        {
+          hasSelection: true,
+          selectionText: 'test',
+          filePath: '/tmp/test.md',
+        }
+      );
+
+      const template = (electron.Menu.buildFromTemplate as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as Array<{ label?: string; click?: () => void }>;
+      const commentItem = template.find((item) => item.label === 'Leave a Comment');
+      commentItem?.click?.();
+
+      const mockWin = deps.getWindow() as { webContents: { send: ReturnType<typeof vi.fn> } };
+      expect(mockWin.webContents.send).toHaveBeenCalledWith(
+        IPC_CHANNELS.MENU_COMMAND,
+        'context:comment'
+      );
+    });
+
+    it('should truncate long selection text in Look Up label', async () => {
+      const electron = await import('electron');
+      const handler = handlers.get(IPC_CHANNELS.SHOW_CONTEXT_MENU);
+      await handler?.(
+        {},
+        {
+          hasSelection: true,
+          selectionText: 'a very long selection text that should be truncated',
+          filePath: '/tmp/test.md',
+        }
+      );
+
+      const template = (electron.Menu.buildFromTemplate as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as Array<{ label?: string }>;
+      const lookupItem = template.find((item) => item.label?.startsWith('Look Up'));
+      expect(lookupItem?.label).toMatch(/\.\.\."/);
+    });
+
+    it('should call menu.popup()', async () => {
+      const electron = await import('electron');
+      const mockMenu = { popup: vi.fn() };
+      (electron.Menu.buildFromTemplate as ReturnType<typeof vi.fn>).mockReturnValue(mockMenu);
+
+      const handler = handlers.get(IPC_CHANNELS.SHOW_CONTEXT_MENU);
+      await handler?.(
+        {},
+        {
+          hasSelection: false,
+          selectionText: '',
+          filePath: '/tmp/test.md',
+        }
+      );
+
+      expect(mockMenu.popup).toHaveBeenCalled();
+    });
+  });
+
+  describe('REVEAL_IN_FINDER', () => {
+    it('should call shell.showItemInFolder with the file path', async () => {
+      const electron = await import('electron');
+      const handler = handlers.get(IPC_CHANNELS.REVEAL_IN_FINDER);
+      await handler?.({}, '/tmp/test.md');
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(vi.mocked(electron.shell.showItemInFolder)).toHaveBeenCalledWith('/tmp/test.md');
+    });
   });
 });

--- a/packages/electron/src/main/ipc-handlers.ts
+++ b/packages/electron/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, shell, type BrowserWindow } from 'electron';
+import { ipcMain, dialog, shell, Menu, type BrowserWindow } from 'electron';
 import { createHash } from 'crypto';
 import { IPC_CHANNELS } from '../shared/ipc-channels';
 import type { StateManager } from './state-manager';
@@ -262,6 +262,73 @@ export function registerIpcHandlers(deps: IPCHandlerDeps): () => void {
 
   ipcMain.handle(IPC_CHANNELS.DELETE_TAB_GROUP, (_event, groupId: string) => {
     stateManager.deleteTabGroup(groupId);
+  });
+
+  // Context menu
+  ipcMain.handle(
+    IPC_CHANNELS.SHOW_CONTEXT_MENU,
+    (_event, context: { hasSelection: boolean; selectionText: string; filePath: string }) => {
+      const win = getWindow();
+      if (!win || win.isDestroyed()) return;
+
+      const sendCommand = (command: string) => {
+        if (!win.isDestroyed()) {
+          win.webContents.send(IPC_CHANNELS.MENU_COMMAND, command);
+        }
+      };
+
+      const template: Electron.MenuItemConstructorOptions[] = [];
+
+      if (context.hasSelection) {
+        const text = context.selectionText;
+        const truncated = text.length > 20 ? text.slice(0, 20) + '...' : text;
+
+        template.push(
+          { label: 'Copy', accelerator: 'CmdOrCtrl+C', click: () => sendCommand('context:copy') },
+          { type: 'separator' },
+          { label: 'Leave a Comment', click: () => sendCommand('context:comment') },
+          { type: 'separator' },
+          {
+            label: `Look Up "${truncated}"`,
+            click: () => sendCommand('context:lookup'),
+          },
+          {
+            label: 'Search with Google',
+            click: () => sendCommand('context:search'),
+          },
+          { type: 'separator' },
+          {
+            label: 'Select All',
+            accelerator: 'CmdOrCtrl+A',
+            click: () => sendCommand('context:select-all'),
+          }
+        );
+      } else {
+        template.push(
+          {
+            label: 'Select All',
+            accelerator: 'CmdOrCtrl+A',
+            click: () => sendCommand('context:select-all'),
+          },
+          { type: 'separator' },
+          { label: 'Copy File Path', click: () => sendCommand('context:copy-path') },
+          { label: 'Reveal in Finder', click: () => sendCommand('context:reveal') },
+          { type: 'separator' },
+          {
+            label: 'Reload',
+            accelerator: 'CmdOrCtrl+R',
+            click: () => sendCommand('context:reload'),
+          }
+        );
+      }
+
+      const menu = Menu.buildFromTemplate(template);
+      menu.popup();
+    }
+  );
+
+  ipcMain.handle(IPC_CHANNELS.REVEAL_IN_FINDER, (_event, filePath: string) => {
+    shell.showItemInFolder(filePath);
   });
 
   // Directory service

--- a/packages/electron/src/main/menu.ts
+++ b/packages/electron/src/main/menu.ts
@@ -166,10 +166,6 @@ export function buildApplicationMenu(deps: MenuDeps): void {
       label: 'Help',
       submenu: [
         {
-          label: 'About Design Review',
-          click: () => onMenuCommand('help:about'),
-        },
-        {
           label: 'View on GitHub',
           click: () => onMenuCommand('help:github'),
         },

--- a/packages/electron/src/main/state-manager.test.ts
+++ b/packages/electron/src/main/state-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { StateManager } from './state-manager';
 import { NoopStorageAdapter } from '@mdreview/core/node';
 
@@ -278,12 +278,63 @@ describe('StateManager', () => {
     });
 
     describe('workspace persistence', () => {
-      it('should persist workspace settings on change', async () => {
+      beforeEach(() => {
+        vi.useFakeTimers();
+      });
+
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('should debounce workspace persistence', () => {
+        const spy = vi.spyOn(storage, 'setLocal');
+
         manager.setSidebarVisible(false);
-        // Allow async persistence to complete
-        await new Promise((r) => setTimeout(r, 10));
+        manager.setSidebarWidth(300);
+        manager.setTabBarVisible(false);
+
+        // No persistence yet — debounce timer hasn't fired
+        expect(spy).not.toHaveBeenCalled();
+
+        // Advance past the 500ms debounce
+        vi.advanceTimersByTime(500);
+
+        // Now it should have persisted exactly once
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should persist workspace after debounce delay', async () => {
+        manager.setSidebarVisible(false);
+        vi.advanceTimersByTime(500);
         const stored = await storage.getLocal(['workspace']);
         expect(stored.workspace).toBeDefined();
+      });
+
+      it('should flush pending persistence immediately', () => {
+        const spy = vi.spyOn(storage, 'setLocal');
+
+        manager.setSidebarVisible(false);
+        expect(spy).not.toHaveBeenCalled();
+
+        manager.flushPersist();
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not double-persist after flush then timer', () => {
+        const spy = vi.spyOn(storage, 'setLocal');
+
+        manager.setSidebarVisible(false);
+        manager.flushPersist();
+        vi.advanceTimersByTime(500);
+
+        // Only the flush call, no extra from timer
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('should be a no-op flush when nothing is pending', () => {
+        const spy = vi.spyOn(storage, 'setLocal');
+        manager.flushPersist();
+        expect(spy).not.toHaveBeenCalled();
       });
     });
 
@@ -364,10 +415,12 @@ describe('StateManager', () => {
       });
 
       it('should persist tab groups', async () => {
+        vi.useFakeTimers();
         const tab = manager.openTab('/tmp/a.md');
         manager.createTabGroup('Research', 'blue', [tab.id]);
 
-        await new Promise((r) => setTimeout(r, 10));
+        vi.advanceTimersByTime(500);
+        vi.useRealTimers();
         const stored = await storage.getLocal(['workspace']);
         const ws = stored.workspace as Record<string, unknown>;
         expect(ws.tabGroups).toBeDefined();

--- a/packages/electron/src/main/state-manager.ts
+++ b/packages/electron/src/main/state-manager.ts
@@ -225,7 +225,25 @@ export class StateManager {
     this.persistWorkspace();
   }
 
+  private persistTimer: ReturnType<typeof setTimeout> | null = null;
+
   private persistWorkspace(): void {
+    if (this.persistTimer) clearTimeout(this.persistTimer);
+    this.persistTimer = setTimeout(() => {
+      this.persistTimer = null;
+      this.persistWorkspaceNow();
+    }, 500);
+  }
+
+  flushPersist(): void {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = null;
+      this.persistWorkspaceNow();
+    }
+  }
+
+  private persistWorkspaceNow(): void {
     void this.storage.setLocal({
       workspace: {
         sidebarVisible: this.workspace.sidebarVisible,

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -55,6 +55,10 @@ const api: MdreviewPreloadAPI = {
   setOpenFolder: (path) => ipcRenderer.invoke(IPC_CHANNELS.SET_OPEN_FOLDER, path),
   openExternal: (url) => ipcRenderer.invoke(IPC_CHANNELS.OPEN_EXTERNAL, url),
 
+  // Context menu
+  showContextMenu: (context) => ipcRenderer.invoke(IPC_CHANNELS.SHOW_CONTEXT_MENU, context),
+  revealInFinder: (path) => ipcRenderer.invoke(IPC_CHANNELS.REVEAL_IN_FINDER, path),
+
   // Tab groups
   createTabGroup: (name, color, tabIds) =>
     ipcRenderer.invoke(IPC_CHANNELS.CREATE_TAB_GROUP, name, color, tabIds),

--- a/packages/electron/src/renderer/document-context.test.ts
+++ b/packages/electron/src/renderer/document-context.test.ts
@@ -42,6 +42,9 @@ vi.mock('@mdreview/core', async () => {
     FileScanner: {
       getFileSize: vi.fn().mockReturnValue(100),
     },
+    mermaidRenderer: {
+      renderAllImmediate: vi.fn().mockResolvedValue(undefined),
+    },
   };
 });
 
@@ -316,6 +319,58 @@ describe('DocumentContext', () => {
       const ctx = new DocumentContext('tab-1');
       await ctx.exportDOCX();
       expect(mockMdview.saveFile).not.toHaveBeenCalled();
+    });
+
+    it('should force-render mermaid diagrams before collecting content', async () => {
+      mockMdview.saveFile = vi.fn().mockResolvedValue(undefined);
+
+      const { DocumentContext } = await import('./document-context');
+      const { mermaidRenderer } = await import('@mdreview/core');
+      const container = document.getElementById('test-container')!;
+      const ctx = new DocumentContext('tab-1');
+      await ctx.load('/tmp/test.md', container);
+
+      // Add a mermaid container to the DOM
+      container.innerHTML = `
+        <div class="mermaid-container mermaid-pending" id="mermaid-test1">
+          <div class="mermaid-loading">Loading...</div>
+        </div>
+      `;
+
+      await ctx.exportDOCX();
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(mermaidRenderer.renderAllImmediate).toHaveBeenCalledWith(container);
+    });
+
+    it('should only query mermaid SVGs, not all SVGs', async () => {
+      mockMdview.saveFile = vi.fn().mockResolvedValue(undefined);
+
+      const { DocumentContext } = await import('./document-context');
+      const { SVGConverter } = await import('@mdreview/core');
+      const container = document.getElementById('test-container')!;
+      const ctx = new DocumentContext('tab-1');
+      await ctx.load('/tmp/test.md', container);
+
+      // Add both a mermaid SVG and a non-mermaid SVG
+      container.innerHTML = `
+        <div class="mermaid-container mermaid-ready" id="mermaid-test1">
+          <div class="mermaid-rendered">
+            <svg width="200" height="100" id="mermaid-svg"></svg>
+          </div>
+        </div>
+        <svg width="16" height="16" id="icon-svg"><circle r="8"/></svg>
+      `;
+
+      await ctx.exportDOCX();
+
+      const converterInstance = (SVGConverter as unknown as ReturnType<typeof vi.fn>).mock
+        .results[0]?.value as Record<string, ReturnType<typeof vi.fn>>;
+      const svgsPassedToConverter = converterInstance.convertAll.mock.calls[0][0] as SVGElement[];
+
+      // Should only include the mermaid SVG, not the icon SVG
+      expect(svgsPassedToConverter).toHaveLength(1);
+      expect(svgsPassedToConverter[0].id).toBe('mermaid-svg');
     });
   });
 

--- a/packages/electron/src/renderer/document-context.test.ts
+++ b/packages/electron/src/renderer/document-context.test.ts
@@ -26,6 +26,7 @@ vi.mock('@mdreview/core', async () => {
     }),
     CommentManager: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
       this.initialize = vi.fn().mockResolvedValue(undefined);
+      this.handleAddCommentRequest = vi.fn();
     }),
     ContentCollector: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
       this.collect = vi.fn().mockReturnValue({ title: 'Test', nodes: [], metadata: {} });
@@ -87,6 +88,8 @@ function createMockMdviewAPI() {
     setSidebarWidth: vi.fn(),
     setOpenFolder: vi.fn(),
     openExternal: vi.fn(),
+    showContextMenu: vi.fn().mockResolvedValue(undefined),
+    revealInFinder: vi.fn().mockResolvedValue(undefined),
     listDirectory: vi.fn(),
     watchDirectory: vi.fn(),
     unwatchDirectory: vi.fn(),
@@ -372,6 +375,205 @@ describe('DocumentContext', () => {
       const mockInstance = (TocRenderer as unknown as ReturnType<typeof vi.fn>).mock.results[0]
         ?.value as Record<string, ReturnType<typeof vi.fn>>;
       expect(mockInstance.hide).toHaveBeenCalled();
+    });
+  });
+
+  describe('native context menu', () => {
+    it('should call showContextMenu with selection context on right-click', async () => {
+      mockMdview.getState.mockResolvedValue({
+        preferences: {
+          theme: 'github-light',
+          autoReload: false,
+          showToc: false,
+          commentsEnabled: true,
+        },
+        document: { path: '', content: '', scrollPosition: 0, renderState: 'pending' },
+        ui: { theme: null, maximizedDiagram: null, visibleDiagrams: new Set() },
+      });
+      mockMdview.showContextMenu = vi.fn().mockResolvedValue(undefined);
+
+      const { DocumentContext } = await import('./document-context');
+      const container = document.getElementById('test-container')!;
+      container.innerHTML = '<p>Some text to select</p>';
+      const ctx = new DocumentContext('tab-cm-1');
+      await ctx.load('/tmp/test.md', container);
+
+      const origGetSelection = window.getSelection;
+      window.getSelection = vi.fn().mockReturnValue({
+        toString: () => 'selected text',
+        isCollapsed: false,
+        rangeCount: 1,
+      }) as unknown as typeof window.getSelection;
+
+      container.dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 100, clientY: 200, bubbles: true })
+      );
+
+      expect(mockMdview.showContextMenu).toHaveBeenCalledWith({
+        hasSelection: true,
+        selectionText: 'selected text',
+        filePath: '/tmp/test.md',
+      });
+
+      window.getSelection = origGetSelection;
+    });
+
+    it('should call showContextMenu without selection when no text selected', async () => {
+      mockMdview.getState.mockResolvedValue({
+        preferences: {
+          theme: 'github-light',
+          autoReload: false,
+          showToc: false,
+          commentsEnabled: true,
+        },
+        document: { path: '', content: '', scrollPosition: 0, renderState: 'pending' },
+        ui: { theme: null, maximizedDiagram: null, visibleDiagrams: new Set() },
+      });
+      mockMdview.showContextMenu = vi.fn().mockResolvedValue(undefined);
+
+      const { DocumentContext } = await import('./document-context');
+      const container = document.getElementById('test-container')!;
+      const ctx = new DocumentContext('tab-cm-2');
+      await ctx.load('/tmp/test.md', container);
+
+      const origGetSelection = window.getSelection;
+      window.getSelection = vi.fn().mockReturnValue({
+        toString: () => '',
+        isCollapsed: true,
+        rangeCount: 0,
+      }) as unknown as typeof window.getSelection;
+
+      container.dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 100, clientY: 200, bubbles: true })
+      );
+
+      expect(mockMdview.showContextMenu).toHaveBeenCalledWith({
+        hasSelection: false,
+        selectionText: '',
+        filePath: '/tmp/test.md',
+      });
+
+      window.getSelection = origGetSelection;
+    });
+
+    it('should handle context:comment by calling commentManager with cached text', async () => {
+      mockMdview.getState.mockResolvedValue({
+        preferences: {
+          theme: 'github-light',
+          autoReload: false,
+          showToc: false,
+          commentsEnabled: true,
+        },
+        document: { path: '', content: '', scrollPosition: 0, renderState: 'pending' },
+        ui: { theme: null, maximizedDiagram: null, visibleDiagrams: new Set() },
+      });
+      mockMdview.showContextMenu = vi.fn().mockResolvedValue(undefined);
+
+      // Capture the onMenuCommand callback
+      let menuCommandCallback: ((command: string) => void) | null = null;
+      mockMdview.onMenuCommand = vi.fn().mockImplementation((cb: (cmd: string) => void) => {
+        menuCommandCallback = cb;
+        return vi.fn();
+      });
+
+      const { DocumentContext } = await import('./document-context');
+      const { CommentManager } = await import('@mdreview/core');
+      const container = document.getElementById('test-container')!;
+      const ctx = new DocumentContext('tab-cm-3');
+      await ctx.load('/tmp/test.md', container);
+
+      // Simulate right-click with selection to cache the text
+      const origGetSelection = window.getSelection;
+      window.getSelection = vi.fn().mockReturnValue({
+        toString: () => 'my selection',
+        isCollapsed: false,
+        rangeCount: 1,
+      }) as unknown as typeof window.getSelection;
+
+      container.dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 100, clientY: 200, bubbles: true })
+      );
+
+      // Simulate the menu command coming back from main process
+      menuCommandCallback?.('context:comment');
+
+      const mockInstance = (CommentManager as unknown as ReturnType<typeof vi.fn>).mock.results[0]
+        ?.value as Record<string, ReturnType<typeof vi.fn>>;
+      expect(mockInstance.handleAddCommentRequest).toHaveBeenCalledWith('my selection');
+
+      window.getSelection = origGetSelection;
+    });
+
+    it('should always set up context menu regardless of comments setting', async () => {
+      // commentsEnabled is false by default
+      mockMdview.showContextMenu = vi.fn().mockResolvedValue(undefined);
+
+      const { DocumentContext } = await import('./document-context');
+      const container = document.getElementById('test-container')!;
+      const ctx = new DocumentContext('tab-cm-4');
+      await ctx.load('/tmp/test.md', container);
+
+      const origGetSelection = window.getSelection;
+      window.getSelection = vi.fn().mockReturnValue({
+        toString: () => '',
+        isCollapsed: true,
+        rangeCount: 0,
+      }) as unknown as typeof window.getSelection;
+
+      container.dispatchEvent(
+        new MouseEvent('contextmenu', { clientX: 100, clientY: 200, bubbles: true })
+      );
+
+      // Native context menu should still appear (with non-comment items)
+      expect(mockMdview.showContextMenu).toHaveBeenCalledWith({
+        hasSelection: false,
+        selectionText: '',
+        filePath: '/tmp/test.md',
+      });
+
+      window.getSelection = origGetSelection;
+    });
+
+    it('should handle context:copy-path by writing file path to clipboard', async () => {
+      mockMdview.showContextMenu = vi.fn().mockResolvedValue(undefined);
+
+      let menuCommandCallback: ((command: string) => void) | null = null;
+      mockMdview.onMenuCommand = vi.fn().mockImplementation((cb: (cmd: string) => void) => {
+        menuCommandCallback = cb;
+        return vi.fn();
+      });
+
+      const writeTextSpy = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(navigator.clipboard, 'writeText').mockImplementation(writeTextSpy);
+
+      const { DocumentContext } = await import('./document-context');
+      const container = document.getElementById('test-container')!;
+      const ctx = new DocumentContext('tab-cm-5');
+      await ctx.load('/tmp/test.md', container);
+
+      menuCommandCallback?.('context:copy-path');
+
+      expect(writeTextSpy).toHaveBeenCalledWith('/tmp/test.md');
+    });
+
+    it('should handle context:reveal by calling revealInFinder', async () => {
+      mockMdview.showContextMenu = vi.fn().mockResolvedValue(undefined);
+      mockMdview.revealInFinder = vi.fn().mockResolvedValue(undefined);
+
+      let menuCommandCallback: ((command: string) => void) | null = null;
+      mockMdview.onMenuCommand = vi.fn().mockImplementation((cb: (cmd: string) => void) => {
+        menuCommandCallback = cb;
+        return vi.fn();
+      });
+
+      const { DocumentContext } = await import('./document-context');
+      const container = document.getElementById('test-container')!;
+      const ctx = new DocumentContext('tab-cm-6');
+      await ctx.load('/tmp/test.md', container);
+
+      menuCommandCallback?.('context:reveal');
+
+      expect(mockMdview.revealInFinder).toHaveBeenCalledWith('/tmp/test.md');
     });
   });
 

--- a/packages/electron/src/renderer/document-context.ts
+++ b/packages/electron/src/renderer/document-context.ts
@@ -9,6 +9,7 @@ import {
   ContentCollector,
   SVGConverter,
   DOCXGenerator,
+  mermaidRenderer,
   type Preferences,
   type RenderProgress,
 } from '@mdreview/core';
@@ -251,9 +252,13 @@ export class DocumentContext {
 
   async exportDOCX(): Promise<void> {
     if (!this.filePath || !this.container) return;
+    // Force-render any lazy-loaded mermaid diagrams before collecting
+    await mermaidRenderer.renderAllImmediate(this.container);
     const collector = new ContentCollector();
     const content = collector.collect(this.container);
-    const svgElements = Array.from(this.container.querySelectorAll('svg')) as SVGElement[];
+    const svgElements = Array.from(
+      this.container.querySelectorAll<SVGElement>('.mermaid-container svg')
+    );
     const converter = new SVGConverter();
     const images = converter.convertAll(svgElements);
     const generator = new DOCXGenerator();

--- a/packages/electron/src/renderer/document-context.ts
+++ b/packages/electron/src/renderer/document-context.ts
@@ -40,6 +40,9 @@ export class DocumentContext {
   private tocRenderer: TocRenderer | null = null;
   private commentManager: CommentManager | null = null;
   private autoReloadCleanup: (() => void) | null = null;
+  private contextMenuCleanup: (() => void) | null = null;
+  private contextMenuActionsCleanup: (() => void) | null = null;
+  private cachedSelectionText = '';
   private onProgressCallback: ((progress: { stage: string; percent: number }) => void) | null =
     null;
   private metadata: DocumentMetadata = {
@@ -110,7 +113,7 @@ export class DocumentContext {
       theme,
       preferences: state.preferences,
       useCache: true,
-      useWorkers: false,
+      useWorkers: true,
     });
 
     cleanupProgress();
@@ -129,8 +132,12 @@ export class DocumentContext {
         file: this.fileAdapter,
         identity: this.identityAdapter,
       });
-      await this.commentManager.initialize(content, filePath, container);
+      await this.commentManager.initialize(content, filePath, state.preferences);
     }
+
+    // Native context menu (always available, with or without comments)
+    this.setupContextMenu(container);
+    this.setupContextMenuActions();
 
     // Auto-reload
     if (state.preferences.autoReload) {
@@ -163,7 +170,7 @@ export class DocumentContext {
       theme: state.preferences.theme || 'github-light',
       preferences: state.preferences,
       useCache: true,
-      useWorkers: false,
+      useWorkers: true,
     });
 
     this.resolveRelativeUrls(this.container, this.filePath);
@@ -285,6 +292,14 @@ export class DocumentContext {
   }
 
   dispose(): void {
+    if (this.contextMenuCleanup) {
+      this.contextMenuCleanup();
+      this.contextMenuCleanup = null;
+    }
+    if (this.contextMenuActionsCleanup) {
+      this.contextMenuActionsCleanup();
+      this.contextMenuActionsCleanup = null;
+    }
     if (this.autoReloadCleanup) {
       this.autoReloadCleanup();
       this.autoReloadCleanup = null;
@@ -341,6 +356,74 @@ export class DocumentContext {
     return result;
   }
 
+  private setupContextMenu(container: HTMLElement): void {
+    const handler = (e: MouseEvent) => {
+      e.preventDefault();
+
+      const selection = window.getSelection();
+      const text = selection?.toString().trim() ?? '';
+      this.cachedSelectionText = text;
+
+      void window.mdreview.showContextMenu({
+        hasSelection: text.length > 0,
+        selectionText: text,
+        filePath: this.filePath!,
+      });
+    };
+
+    container.addEventListener('contextmenu', handler);
+    this.contextMenuCleanup = () => container.removeEventListener('contextmenu', handler);
+  }
+
+  private setupContextMenuActions(): void {
+    const cleanup = window.mdreview.onMenuCommand((command: string) => {
+      if (!command.startsWith('context:')) return;
+
+      switch (command) {
+        case 'context:copy':
+          document.execCommand('copy');
+          break;
+        case 'context:select-all':
+          document.execCommand('selectAll');
+          break;
+        case 'context:comment':
+          if (this.commentManager && this.cachedSelectionText) {
+            this.commentManager.handleAddCommentRequest(this.cachedSelectionText);
+          }
+          break;
+        case 'context:copy-path':
+          if (this.filePath) {
+            void navigator.clipboard.writeText(this.filePath);
+          }
+          break;
+        case 'context:reveal':
+          if (this.filePath) {
+            void window.mdreview.revealInFinder(this.filePath);
+          }
+          break;
+        case 'context:reload':
+          void this.reload();
+          break;
+        case 'context:lookup':
+          if (this.cachedSelectionText) {
+            void window.mdreview.openExternal(
+              `dict://${encodeURIComponent(this.cachedSelectionText)}`
+            );
+          }
+          break;
+        case 'context:search':
+          if (this.cachedSelectionText) {
+            void window.mdreview.openExternal(
+              `https://www.google.com/search?q=${encodeURIComponent(this.cachedSelectionText)}`
+            );
+          }
+          break;
+      }
+    });
+
+    this.contextMenuActionsCleanup = cleanup;
+  }
+
   private resolveRelativeUrls(container: HTMLElement, filePath: string): void {
     const dirPath = filePath.substring(0, filePath.lastIndexOf('/'));
 
@@ -394,8 +477,14 @@ export class DocumentContext {
     let reloadTimeout: ReturnType<typeof setTimeout> | null = null;
 
     const unwatch = this.fileAdapter.watch(filePath, () => {
+      // Skip reload if we just wrote comments
+      if (this.commentManager?.isWriteInProgress()) return;
+
       if (reloadTimeout) clearTimeout(reloadTimeout);
       reloadTimeout = setTimeout(() => {
+        // Re-check write guard inside the debounce window
+        if (this.commentManager?.isWriteInProgress()) return;
+
         void (async () => {
           try {
             const newContent = await this.fileAdapter.readFile(filePath);
@@ -409,7 +498,7 @@ export class DocumentContext {
                 theme: preferences.theme || 'github-light',
                 preferences,
                 useCache: true,
-                useWorkers: false,
+                useWorkers: true,
               });
               this.updateMetadata(container, newContent);
             }

--- a/packages/electron/src/renderer/file-tree.test.ts
+++ b/packages/electron/src/renderer/file-tree.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { FileTree } from './file-tree';
 import type { DirectoryEntry } from '../shared/workspace-types';
 
-function createEntries(): DirectoryEntry[] {
+/** Entries with children already loaded (pre-expanded) */
+function createLoadedEntries(): DirectoryEntry[] {
   return [
     {
       name: 'docs',
@@ -17,20 +18,16 @@ function createEntries(): DirectoryEntry[] {
   ];
 }
 
-function createMixedEntries(): DirectoryEntry[] {
+/** Shallow entries — directories have children: undefined (not loaded yet) */
+function createShallowEntries(): DirectoryEntry[] {
   return [
     {
-      name: 'src',
-      path: '/project/src',
+      name: 'docs',
+      path: '/project/docs',
       type: 'directory',
-      children: [
-        { name: 'app.ts', path: '/project/src/app.ts', type: 'file' },
-        { name: 'index.md', path: '/project/src/index.md', type: 'file' },
-      ],
+      // children: undefined — not loaded yet
     },
     { name: 'readme.md', path: '/project/readme.md', type: 'file' },
-    { name: 'package.json', path: '/project/package.json', type: 'file' },
-    { name: 'logo.png', path: '/project/logo.png', type: 'file' },
   ];
 }
 
@@ -53,24 +50,52 @@ describe('FileTree', () => {
 
   it('should display directory entries as tree', () => {
     fileTree.render(parent);
-    fileTree.loadDirectory(createEntries());
+    fileTree.loadDirectory(createShallowEntries());
 
     const items = parent.querySelectorAll('.file-tree-item');
-    // docs dir + 2 children + readme.md = 4 items
-    expect(items.length).toBe(4);
+    // docs dir + readme.md = 2 items (docs children not loaded)
+    expect(items.length).toBe(2);
   });
 
-  it('should expand and collapse directories on click', () => {
+  it('should start directories collapsed when children are undefined', () => {
     fileTree.render(parent);
-    fileTree.loadDirectory(createEntries());
+    fileTree.loadDirectory(createShallowEntries());
 
     const dirItem = parent.querySelector('.file-tree-directory') as HTMLElement;
     expect(dirItem).not.toBeNull();
 
-    // Initially expanded
     const childContainer = dirItem
       .closest('.file-tree-item')!
       .querySelector('.file-tree-children') as HTMLElement;
+    expect(childContainer.style.display).toBe('none');
+
+    const disclosure = parent.querySelector('.file-tree-disclosure') as HTMLElement;
+    expect(disclosure.classList.contains('expanded')).toBe(false);
+  });
+
+  it('should start directories expanded when children are loaded', () => {
+    fileTree.render(parent);
+    fileTree.loadDirectory(createLoadedEntries());
+
+    const dirItem = parent.querySelector('.file-tree-directory') as HTMLElement;
+    expect(dirItem).not.toBeNull();
+
+    const childContainer = dirItem
+      .closest('.file-tree-item')!
+      .querySelector('.file-tree-children') as HTMLElement;
+    expect(childContainer.style.display).not.toBe('none');
+  });
+
+  it('should expand and collapse directories on click', () => {
+    fileTree.render(parent);
+    fileTree.loadDirectory(createLoadedEntries());
+
+    const dirItem = parent.querySelector('.file-tree-directory') as HTMLElement;
+    const childContainer = dirItem
+      .closest('.file-tree-item')!
+      .querySelector('.file-tree-children') as HTMLElement;
+
+    // Initially expanded (children are loaded)
     expect(childContainer.style.display).not.toBe('none');
 
     // Click to collapse
@@ -86,7 +111,7 @@ describe('FileTree', () => {
     const callback = vi.fn();
     fileTree.render(parent);
     fileTree.onFileSelected(callback);
-    fileTree.loadDirectory(createEntries());
+    fileTree.loadDirectory(createLoadedEntries());
 
     const fileItems = parent.querySelectorAll('.file-tree-file');
     expect(fileItems.length).toBeGreaterThan(0);
@@ -110,7 +135,7 @@ describe('FileTree', () => {
 
   it('should refresh with new entries', () => {
     fileTree.render(parent);
-    fileTree.loadDirectory(createEntries());
+    fileTree.loadDirectory(createShallowEntries());
 
     const newEntries: DirectoryEntry[] = [
       { name: 'changelog.md', path: '/project/changelog.md', type: 'file' },
@@ -132,9 +157,8 @@ describe('FileTree', () => {
 
   it('should show directories before files', () => {
     fileTree.render(parent);
-    fileTree.loadDirectory(createEntries());
+    fileTree.loadDirectory(createShallowEntries());
 
-    // Get top-level items only (depth 0)
     const topLevel = parent.querySelector('.file-tree-list')!.children;
     const topLevelItems = Array.from(topLevel);
 
@@ -145,7 +169,7 @@ describe('FileTree', () => {
 
   it('should mark active file', () => {
     fileTree.render(parent);
-    fileTree.loadDirectory(createEntries());
+    fileTree.loadDirectory(createLoadedEntries());
 
     fileTree.setActiveFile('/project/docs/api.md');
 
@@ -156,7 +180,7 @@ describe('FileTree', () => {
 
   it('should dispose cleanly', () => {
     fileTree.render(parent);
-    fileTree.loadDirectory(createEntries());
+    fileTree.loadDirectory(createShallowEntries());
 
     fileTree.dispose();
 
@@ -167,7 +191,7 @@ describe('FileTree', () => {
   describe('rerender', () => {
     it('should rebuild DOM from stored entries', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const itemsBefore = parent.querySelectorAll('.file-tree-item');
       expect(itemsBefore.length).toBe(4);
@@ -180,7 +204,7 @@ describe('FileTree', () => {
 
     it('should preserve active file across rerender', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
       fileTree.setActiveFile('/project/docs/api.md');
 
       fileTree.rerender();
@@ -202,12 +226,11 @@ describe('FileTree', () => {
   describe('file icons', () => {
     it('should render file-type icons in file items', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const icons = parent.querySelectorAll('.file-tree-icon');
       expect(icons.length).toBeGreaterThan(0);
 
-      // Every icon should contain an SVG element
       for (const icon of icons) {
         expect(icon.querySelector('svg')).not.toBeNull();
       }
@@ -215,15 +238,15 @@ describe('FileTree', () => {
 
     it('should render folder icons with file-tree-icon-folder class', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createShallowEntries());
 
       const folderIcons = parent.querySelectorAll('.file-tree-icon-folder');
-      expect(folderIcons.length).toBe(1); // one directory entry
+      expect(folderIcons.length).toBe(1);
     });
 
     it('should render disclosure triangles on directories', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createShallowEntries());
 
       const disclosures = parent.querySelectorAll('.file-tree-disclosure');
       expect(disclosures.length).toBe(1);
@@ -231,12 +254,12 @@ describe('FileTree', () => {
 
     it('should rotate disclosure triangle on expand/collapse', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const dirLabel = parent.querySelector('.file-tree-directory') as HTMLElement;
       const disclosure = parent.querySelector('.file-tree-disclosure') as HTMLElement;
 
-      // Initially expanded
+      // Initially expanded (children loaded)
       expect(disclosure.classList.contains('expanded')).toBe(true);
 
       // Click to collapse
@@ -250,7 +273,7 @@ describe('FileTree', () => {
 
     it('should render file names in a dedicated span', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const names = parent.querySelectorAll('.file-tree-name');
       expect(names.length).toBeGreaterThan(0);
@@ -328,7 +351,6 @@ describe('FileTree', () => {
       expect(dirName.textContent).toContain('src');
       expect(dirName.textContent).toContain('components');
 
-      // Should have a separator
       const sep = dirName.querySelector('.file-tree-path-sep');
       expect(sep).not.toBeNull();
     });
@@ -348,9 +370,8 @@ describe('FileTree', () => {
 
     it('should not compact when directory has multiple children', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
-      // docs has 2 file children — should NOT be compacted
       const dirs = parent.querySelectorAll('.file-tree-directory');
       expect(dirs.length).toBe(1);
 
@@ -379,7 +400,6 @@ describe('FileTree', () => {
       fileTree.loadDirectory(createCompactableEntries());
 
       const dir = parent.querySelector('.file-tree-directory') as HTMLElement;
-      // The path should be the deepest compacted folder
       expect(dir.dataset.path).toBe('/project/src/components');
     });
 
@@ -392,7 +412,7 @@ describe('FileTree', () => {
         .closest('.file-tree-item')!
         .querySelector('.file-tree-children') as HTMLElement;
 
-      // Initially expanded
+      // Initially expanded (children are loaded)
       expect(childContainer.style.display).not.toBe('none');
 
       // Collapse
@@ -405,10 +425,157 @@ describe('FileTree', () => {
     });
   });
 
+  describe('lazy expand', () => {
+    it('should invoke onDirectoryExpand callback when expanding unloaded directory', async () => {
+      const expandCallback = vi
+        .fn()
+        .mockResolvedValue([{ name: 'guide.md', path: '/project/docs/guide.md', type: 'file' }]);
+
+      fileTree.render(parent);
+      fileTree.onDirectoryExpand(expandCallback);
+      fileTree.loadDirectory(createShallowEntries());
+
+      const dirLabel = parent.querySelector('.file-tree-directory') as HTMLElement;
+      dirLabel.click();
+
+      // Wait for async callback
+      await vi.waitFor(() => {
+        expect(expandCallback).toHaveBeenCalledWith('/project/docs');
+      });
+    });
+
+    it('should render children after lazy load completes', async () => {
+      const expandCallback = vi.fn().mockResolvedValue([
+        { name: 'guide.md', path: '/project/docs/guide.md', type: 'file' },
+        { name: 'api.md', path: '/project/docs/api.md', type: 'file' },
+      ]);
+
+      fileTree.render(parent);
+      fileTree.onDirectoryExpand(expandCallback);
+      fileTree.loadDirectory(createShallowEntries());
+
+      // Before expand: only 2 top-level items
+      expect(parent.querySelectorAll('.file-tree-item').length).toBe(2);
+
+      const dirLabel = parent.querySelector('.file-tree-directory') as HTMLElement;
+      dirLabel.click();
+
+      await vi.waitFor(() => {
+        // After expand: 2 top-level + 2 children = 4
+        expect(parent.querySelectorAll('.file-tree-item').length).toBe(4);
+      });
+
+      // Children container should be visible
+      const childContainer = dirLabel
+        .closest('.file-tree-item')!
+        .querySelector('.file-tree-children') as HTMLElement;
+      expect(childContainer.style.display).not.toBe('none');
+    });
+
+    it('should not invoke callback on second expand (uses cached children)', async () => {
+      const expandCallback = vi
+        .fn()
+        .mockResolvedValue([{ name: 'guide.md', path: '/project/docs/guide.md', type: 'file' }]);
+
+      fileTree.render(parent);
+      fileTree.onDirectoryExpand(expandCallback);
+      fileTree.loadDirectory(createShallowEntries());
+
+      const dirLabel = parent.querySelector('.file-tree-directory') as HTMLElement;
+
+      // First click: expands and loads
+      dirLabel.click();
+      await vi.waitFor(() => {
+        expect(expandCallback).toHaveBeenCalledTimes(1);
+      });
+
+      // Second click: collapse
+      dirLabel.click();
+
+      // Third click: expand again — should NOT call callback again
+      dirLabel.click();
+      expect(expandCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should auto-expand compact chain on lazy load', async () => {
+      // When loading returns a single directory child, auto-expand it
+      const expandCallback = vi
+        .fn()
+        .mockResolvedValueOnce([
+          { name: 'components', path: '/project/src/components', type: 'directory' },
+        ])
+        .mockResolvedValueOnce([
+          { name: 'Button.tsx', path: '/project/src/components/Button.tsx', type: 'file' },
+          { name: 'Input.tsx', path: '/project/src/components/Input.tsx', type: 'file' },
+        ]);
+
+      const entries: DirectoryEntry[] = [{ name: 'src', path: '/project/src', type: 'directory' }];
+
+      fileTree.render(parent);
+      fileTree.onDirectoryExpand(expandCallback);
+      fileTree.loadDirectory(entries);
+
+      const dirLabel = parent.querySelector('.file-tree-directory') as HTMLElement;
+      dirLabel.click();
+
+      await vi.waitFor(() => {
+        // Should have auto-expanded the chain: src/components shown compacted
+        // with 2 file children
+        expect(expandCallback).toHaveBeenCalledTimes(2);
+        expect(expandCallback).toHaveBeenCalledWith('/project/src');
+        expect(expandCallback).toHaveBeenCalledWith('/project/src/components');
+      });
+
+      await vi.waitFor(() => {
+        // The directory label should show compacted name
+        const dirName = parent.querySelector('.file-tree-directory .file-tree-name') as HTMLElement;
+        expect(dirName.textContent).toContain('src');
+        expect(dirName.textContent).toContain('components');
+      });
+    });
+
+    it('should show disclosure as expanded after lazy load', async () => {
+      const expandCallback = vi
+        .fn()
+        .mockResolvedValue([{ name: 'guide.md', path: '/project/docs/guide.md', type: 'file' }]);
+
+      fileTree.render(parent);
+      fileTree.onDirectoryExpand(expandCallback);
+      fileTree.loadDirectory(createShallowEntries());
+
+      const disclosure = parent.querySelector('.file-tree-disclosure') as HTMLElement;
+      expect(disclosure.classList.contains('expanded')).toBe(false);
+
+      const dirLabel = parent.querySelector('.file-tree-directory') as HTMLElement;
+      dirLabel.click();
+
+      await vi.waitFor(() => {
+        expect(disclosure.classList.contains('expanded')).toBe(true);
+      });
+    });
+  });
+
   describe('non-markdown files', () => {
+    function createMixedLoadedEntries(): DirectoryEntry[] {
+      return [
+        {
+          name: 'src',
+          path: '/project/src',
+          type: 'directory',
+          children: [
+            { name: 'app.ts', path: '/project/src/app.ts', type: 'file' },
+            { name: 'index.md', path: '/project/src/index.md', type: 'file' },
+          ],
+        },
+        { name: 'readme.md', path: '/project/readme.md', type: 'file' },
+        { name: 'package.json', path: '/project/package.json', type: 'file' },
+        { name: 'logo.png', path: '/project/logo.png', type: 'file' },
+      ];
+    }
+
     it('should add file-tree-file-readonly class to non-markdown files', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createMixedEntries());
+      fileTree.loadDirectory(createMixedLoadedEntries());
 
       const readonlyFiles = parent.querySelectorAll('.file-tree-file-readonly');
       // package.json, logo.png, app.ts are non-markdown
@@ -419,7 +586,7 @@ describe('FileTree', () => {
       const callback = vi.fn();
       fileTree.render(parent);
       fileTree.onFileSelected(callback);
-      fileTree.loadDirectory(createMixedEntries());
+      fileTree.loadDirectory(createMixedLoadedEntries());
 
       const readonlyFile = parent.querySelector('.file-tree-file-readonly') as HTMLElement;
       readonlyFile.click();
@@ -431,9 +598,8 @@ describe('FileTree', () => {
       const callback = vi.fn();
       fileTree.render(parent);
       fileTree.onFileSelected(callback);
-      fileTree.loadDirectory(createMixedEntries());
+      fileTree.loadDirectory(createMixedLoadedEntries());
 
-      // Find the readme.md file (not readonly)
       const mdFiles = parent.querySelectorAll('.file-tree-file:not(.file-tree-file-readonly)');
       expect(mdFiles.length).toBeGreaterThan(0);
 
@@ -443,7 +609,7 @@ describe('FileTree', () => {
 
     it('should show context menu with only path items for non-markdown files', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createMixedEntries());
+      fileTree.loadDirectory(createMixedLoadedEntries());
 
       const readonlyFile = parent.querySelector('.file-tree-file-readonly') as HTMLElement;
       readonlyFile.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -455,7 +621,6 @@ describe('FileTree', () => {
       const labels = Array.from(items).map((i) => i.textContent);
       expect(labels).toContain('Copy Path');
       expect(labels).toContain('Copy Relative Path');
-      // Should NOT have Open/Export items
       expect(labels).not.toContain('Open File');
       expect(labels).not.toContain('Export as PDF');
     });
@@ -464,7 +629,7 @@ describe('FileTree', () => {
   describe('context menu', () => {
     it('should show context menu on right-click of a file', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -475,7 +640,7 @@ describe('FileTree', () => {
 
     it('should have Open, Export PDF, and Export DOCX items', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -491,7 +656,7 @@ describe('FileTree', () => {
       const callback = vi.fn();
       fileTree.render(parent);
       fileTree.onFileSelected(callback);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -507,7 +672,7 @@ describe('FileTree', () => {
       const exportCallback = vi.fn();
       fileTree.render(parent);
       fileTree.onFileExport(exportCallback);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -525,7 +690,7 @@ describe('FileTree', () => {
       const exportCallback = vi.fn();
       fileTree.render(parent);
       fileTree.onFileExport(exportCallback);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -541,7 +706,7 @@ describe('FileTree', () => {
 
     it('should show context menu with path items on right-click of a directory', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const dirItem = parent.querySelector('.file-tree-directory') as HTMLElement;
       dirItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -553,21 +718,19 @@ describe('FileTree', () => {
       const labels = Array.from(items).map((i) => i.textContent);
       expect(labels).toContain('Copy Path');
       expect(labels).toContain('Copy Relative Path');
-      // Should NOT have Open/Export items
       expect(labels).not.toContain('Open File');
       expect(labels).not.toContain('Export as PDF');
     });
 
     it('should dismiss context menu on outside click', async () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
 
       expect(document.querySelector('.tab-context-menu')).not.toBeNull();
 
-      // Wait for setTimeout(0) dismiss handler registration
       await new Promise((r) => setTimeout(r, 0));
       document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
@@ -576,7 +739,7 @@ describe('FileTree', () => {
 
     it('markdown file context menu includes Copy Path and Copy Relative Path', () => {
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -592,7 +755,7 @@ describe('FileTree', () => {
       Object.assign(navigator, { clipboard: { writeText } });
 
       fileTree.render(parent);
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -610,7 +773,7 @@ describe('FileTree', () => {
 
       fileTree.render(parent);
       fileTree.setRootPath('/project');
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));
@@ -629,8 +792,7 @@ describe('FileTree', () => {
       Object.assign(navigator, { clipboard: { writeText } });
 
       fileTree.render(parent);
-      // Don't call setRootPath
-      fileTree.loadDirectory(createEntries());
+      fileTree.loadDirectory(createLoadedEntries());
 
       const fileItem = parent.querySelector('.file-tree-file') as HTMLElement;
       fileItem.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true }));

--- a/packages/electron/src/renderer/file-tree.ts
+++ b/packages/electron/src/renderer/file-tree.ts
@@ -6,6 +6,7 @@ export class FileTree {
   private visible = true;
   private fileSelectCallback: ((path: string) => void) | null = null;
   private fileExportCallback: ((path: string, format: 'pdf' | 'docx') => void) | null = null;
+  private directoryExpandCallback: ((dirPath: string) => Promise<DirectoryEntry[]>) | null = null;
   private activeFilePath: string | null = null;
   private activeContextMenu: HTMLElement | null = null;
   private contextMenuDismissHandler: ((e: MouseEvent) => void) | null = null;
@@ -59,6 +60,10 @@ export class FileTree {
     this.fileExportCallback = callback;
   }
 
+  onDirectoryExpand(callback: (dirPath: string) => Promise<DirectoryEntry[]>): void {
+    this.directoryExpandCallback = callback;
+  }
+
   setActiveFile(filePath: string): void {
     this.activeFilePath = filePath;
 
@@ -94,6 +99,7 @@ export class FileTree {
     }
     this.fileSelectCallback = null;
     this.fileExportCallback = null;
+    this.directoryExpandCallback = null;
     this.activeFilePath = null;
     this.rootPath = null;
     this.lastEntries = null;
@@ -106,9 +112,14 @@ export class FileTree {
       item.style.paddingLeft = `${8 + depth * 8}px`;
 
       if (entry.type === 'directory') {
-        // Compact single-child directory chains (VSCode-style)
-        const { segments, finalEntry } = this.compactFolderChain(entry);
-        this.buildDirectoryItem(item, finalEntry, depth, segments);
+        if (entry.children !== undefined) {
+          // Children already loaded — compact and render synchronously
+          const { segments, finalEntry } = this.compactFolderChain(entry);
+          this.buildDirectoryItem(item, finalEntry, depth, segments, true);
+        } else {
+          // Children not loaded — render collapsed, load on expand
+          this.buildDirectoryItem(item, entry, depth, [entry.name], false);
+        }
       } else {
         this.buildFileItem(item, entry);
       }
@@ -121,7 +132,10 @@ export class FileTree {
    * Walk a chain of single-child directories and collect their names.
    * Returns the segments and the deepest entry whose children should be rendered.
    */
-  private compactFolderChain(entry: DirectoryEntry): { segments: string[]; finalEntry: DirectoryEntry } {
+  private compactFolderChain(entry: DirectoryEntry): {
+    segments: string[];
+    finalEntry: DirectoryEntry;
+  } {
     const segments = [entry.name];
     let current = entry;
 
@@ -141,7 +155,8 @@ export class FileTree {
     item: HTMLElement,
     entry: DirectoryEntry,
     depth: number,
-    segments: string[] = [entry.name],
+    segments: string[],
+    startExpanded: boolean
   ): void {
     const label = document.createElement('div');
     label.className = 'file-tree-directory';
@@ -149,30 +164,18 @@ export class FileTree {
 
     // Disclosure triangle
     const disclosure = document.createElement('span');
-    disclosure.className = 'file-tree-disclosure expanded';
+    disclosure.className = startExpanded ? 'file-tree-disclosure expanded' : 'file-tree-disclosure';
     disclosure.textContent = '\u25B6';
 
     // Folder icon
     const icon = document.createElement('span');
     icon.className = 'file-tree-icon file-tree-icon-folder';
-    icon.innerHTML = getFileIconSVG(entry.name, true, true);
+    icon.innerHTML = getFileIconSVG(entry.name, true, startExpanded);
 
     // Name — render compound segments with separators
     const nameSpan = document.createElement('span');
     nameSpan.className = 'file-tree-name';
-    if (segments.length === 1) {
-      nameSpan.textContent = segments[0];
-    } else {
-      for (let i = 0; i < segments.length; i++) {
-        if (i > 0) {
-          const sep = document.createElement('span');
-          sep.className = 'file-tree-path-sep';
-          sep.textContent = ' / ';
-          nameSpan.appendChild(sep);
-        }
-        nameSpan.appendChild(document.createTextNode(segments[i]));
-      }
-    }
+    this.renderSegments(nameSpan, segments);
 
     label.appendChild(disclosure);
     label.appendChild(icon);
@@ -181,9 +184,50 @@ export class FileTree {
     const childContainer = document.createElement('div');
     childContainer.className = 'file-tree-children';
 
-    let expanded = true;
+    let expanded = startExpanded;
+    let loaded = entry.children !== undefined;
+
+    if (!expanded) {
+      childContainer.style.display = 'none';
+    }
 
     label.addEventListener('click', () => {
+      if (!loaded && !expanded && this.directoryExpandCallback) {
+        // Lazy load children
+        void this.directoryExpandCallback(entry.path).then((children) => {
+          loaded = true;
+          expanded = true;
+
+          // Check for compact chain: single directory child
+          if (
+            children.length === 1 &&
+            children[0].type === 'directory' &&
+            children[0].children === undefined
+          ) {
+            this.lazyCompactChain(
+              item,
+              entry,
+              children[0],
+              depth,
+              segments,
+              label,
+              disclosure,
+              icon,
+              nameSpan,
+              childContainer
+            );
+            return;
+          }
+
+          entry.children = children;
+          childContainer.style.display = '';
+          disclosure.classList.add('expanded');
+          icon.innerHTML = getFileIconSVG(entry.name, true, true);
+          this.buildTree(childContainer, children, depth + 1);
+        });
+        return;
+      }
+
       expanded = !expanded;
       childContainer.style.display = expanded ? '' : 'none';
       disclosure.classList.toggle('expanded', expanded);
@@ -203,6 +247,80 @@ export class FileTree {
     }
 
     item.appendChild(childContainer);
+  }
+
+  /**
+   * Handle lazy compact chain: when expanding a directory reveals a single
+   * directory child, auto-expand it and merge into a compacted display.
+   */
+  private lazyCompactChain(
+    item: HTMLElement,
+    parentEntry: DirectoryEntry,
+    childDirEntry: DirectoryEntry,
+    depth: number,
+    segments: string[],
+    label: HTMLElement,
+    disclosure: HTMLElement,
+    icon: HTMLElement,
+    nameSpan: HTMLElement,
+    childContainer: HTMLElement
+  ): void {
+    if (!this.directoryExpandCallback) return;
+
+    const newSegments = [...segments, childDirEntry.name];
+
+    void this.directoryExpandCallback(childDirEntry.path).then((grandchildren) => {
+      // Check if we should keep compacting
+      if (
+        grandchildren.length === 1 &&
+        grandchildren[0].type === 'directory' &&
+        grandchildren[0].children === undefined
+      ) {
+        this.lazyCompactChain(
+          item,
+          childDirEntry,
+          grandchildren[0],
+          depth,
+          newSegments,
+          label,
+          disclosure,
+          icon,
+          nameSpan,
+          childContainer
+        );
+        return;
+      }
+
+      // Terminal case: render the compacted result
+      childDirEntry.children = grandchildren;
+      parentEntry.children = [childDirEntry];
+
+      // Update label to show compacted path
+      label.dataset.path = childDirEntry.path;
+      this.renderSegments(nameSpan, newSegments);
+
+      childContainer.style.display = '';
+      disclosure.classList.add('expanded');
+      icon.innerHTML = getFileIconSVG(childDirEntry.name, true, true);
+      this.buildTree(childContainer, grandchildren, depth + 1);
+    });
+  }
+
+  private renderSegments(nameSpan: HTMLElement, segments: string[]): void {
+    nameSpan.innerHTML = '';
+    if (segments.length === 1) {
+      nameSpan.textContent = segments[0];
+    } else {
+      for (let i = 0; i < segments.length; i++) {
+        if (i > 0) {
+          const sep = document.createElement('span');
+          sep.className = 'file-tree-path-sep';
+          sep.textContent = ' / ';
+          nameSpan.appendChild(sep);
+        }
+        nameSpan.appendChild(document.createTextNode(segments[i]));
+      }
+    }
   }
 
   private buildFileItem(item: HTMLElement, entry: DirectoryEntry): void {
@@ -258,22 +376,28 @@ export class FileTree {
     menu.style.top = `${y}px`;
 
     // Open File
-    menu.appendChild(this.createMenuItem('Open File', () => {
-      this.fileSelectCallback?.(filePath);
-    }));
+    menu.appendChild(
+      this.createMenuItem('Open File', () => {
+        this.fileSelectCallback?.(filePath);
+      })
+    );
 
     // Separator
     menu.appendChild(this.createSeparator());
 
     // Export as PDF
-    menu.appendChild(this.createMenuItem('Export as PDF', () => {
-      this.fileExportCallback?.(filePath, 'pdf');
-    }));
+    menu.appendChild(
+      this.createMenuItem('Export as PDF', () => {
+        this.fileExportCallback?.(filePath, 'pdf');
+      })
+    );
 
     // Export as DOCX
-    menu.appendChild(this.createMenuItem('Export as DOCX', () => {
-      this.fileExportCallback?.(filePath, 'docx');
-    }));
+    menu.appendChild(
+      this.createMenuItem('Export as DOCX', () => {
+        this.fileExportCallback?.(filePath, 'docx');
+      })
+    );
 
     // Separator before path items
     menu.appendChild(this.createSeparator());
@@ -298,13 +422,17 @@ export class FileTree {
   }
 
   private appendCopyPathItems(menu: HTMLElement, path: string): void {
-    menu.appendChild(this.createMenuItem('Copy Path', () => {
-      void navigator.clipboard.writeText(path);
-    }));
+    menu.appendChild(
+      this.createMenuItem('Copy Path', () => {
+        void navigator.clipboard.writeText(path);
+      })
+    );
 
-    menu.appendChild(this.createMenuItem('Copy Relative Path', () => {
-      void navigator.clipboard.writeText(this.getRelativePath(path));
-    }));
+    menu.appendChild(
+      this.createMenuItem('Copy Relative Path', () => {
+        void navigator.clipboard.writeText(this.getRelativePath(path));
+      })
+    );
   }
 
   private showMenu(menu: HTMLElement): void {

--- a/packages/electron/src/renderer/index.ts
+++ b/packages/electron/src/renderer/index.ts
@@ -8,7 +8,7 @@ import { MDReviewElectronViewer } from './viewer';
 // rewritten from relative paths during content preprocessing.
 DOMPurifierUtil.configure({
   ALLOWED_URI_REGEXP:
-    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|local-asset):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
+    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|local-asset|app):|[^a-z]|[a-z+.-]+(?:[^a-z+.-:]|$))/i,
 });
 
 // Apply theme immediately — before viewer construction — so all workspace

--- a/packages/electron/src/renderer/viewer.test.ts
+++ b/packages/electron/src/renderer/viewer.test.ts
@@ -276,46 +276,6 @@ describe('MDReviewElectronViewer', () => {
       expect(mockMdview.saveFile).toHaveBeenCalled();
     });
 
-    it('should show about modal on help:about', async () => {
-      const { MDReviewElectronViewer } = await import('./viewer');
-      const viewer = new MDReviewElectronViewer();
-      await viewer.initialize();
-
-      const menuCallback = mockMdview.onMenuCommand.mock.calls[0][0] as (cmd: string) => void;
-      menuCallback('help:about');
-
-      const modal = document.querySelector('.mdreview-about-modal');
-      expect(modal).not.toBeNull();
-      expect(modal?.textContent).toContain('Design Review');
-    });
-
-    it('should dismiss about modal on click', async () => {
-      const { MDReviewElectronViewer } = await import('./viewer');
-      const viewer = new MDReviewElectronViewer();
-      await viewer.initialize();
-
-      const menuCallback = mockMdview.onMenuCommand.mock.calls[0][0] as (cmd: string) => void;
-      menuCallback('help:about');
-
-      const modal = document.querySelector('.mdreview-about-modal') as HTMLElement;
-      modal.click();
-
-      expect(document.querySelector('.mdreview-about-modal')).toBeNull();
-    });
-
-    it('should dismiss about modal on Escape', async () => {
-      const { MDReviewElectronViewer } = await import('./viewer');
-      const viewer = new MDReviewElectronViewer();
-      await viewer.initialize();
-
-      const menuCallback = mockMdview.onMenuCommand.mock.calls[0][0] as (cmd: string) => void;
-      menuCallback('help:about');
-
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
-
-      expect(document.querySelector('.mdreview-about-modal')).toBeNull();
-    });
-
     it('should call openExternal on help:github', async () => {
       const { MDReviewElectronViewer } = await import('./viewer');
       const viewer = new MDReviewElectronViewer();

--- a/packages/electron/src/renderer/viewer.ts
+++ b/packages/electron/src/renderer/viewer.ts
@@ -103,6 +103,11 @@ export class MDReviewElectronViewer {
           }
         });
       });
+      this.fileTree.onDirectoryExpand(async (dirPath) => {
+        const state = await window.mdreview.getState();
+        const showAllFiles = state.preferences.showAllFiles ?? false;
+        return window.mdreview.listDirectory(dirPath, { showAllFiles });
+      });
 
       // Sidebar resize handle
       const workspaceEl = document.getElementById('mdreview-workspace');

--- a/packages/electron/src/renderer/viewer.ts
+++ b/packages/electron/src/renderer/viewer.ts
@@ -429,8 +429,6 @@ export class MDReviewElectronViewer {
       if (ctx) {
         void ctx.exportDOCX();
       }
-    } else if (command === 'help:about') {
-      this.showAboutModal();
     } else if (command === 'help:github') {
       void window.mdreview.openExternal('https://github.com/yaklabco/mdreview');
     } else if (command === 'preferences') {
@@ -493,34 +491,6 @@ export class MDReviewElectronViewer {
       },
       MDReviewElectronViewer.AVAILABLE_THEMES
     );
-  }
-
-  private showAboutModal(): void {
-    // Don't create duplicate modals
-    if (document.querySelector('.mdreview-about-modal')) return;
-
-    const modal = document.createElement('div');
-    modal.className = 'mdreview-about-modal';
-    modal.innerHTML = `
-      <div class="mdreview-about-card">
-        <h2>Design Review</h2>
-        <p>An app for design review of software projects</p>
-        <p>Version 0.3.4</p>
-      </div>
-    `;
-
-    const dismiss = () => modal.remove();
-    modal.addEventListener('click', dismiss);
-
-    const onEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        dismiss();
-        document.removeEventListener('keydown', onEscape);
-      }
-    };
-    document.addEventListener('keydown', onEscape);
-
-    document.body.appendChild(modal);
   }
 
   private setupIPCListeners(): void {

--- a/packages/electron/src/renderer/workspace.css
+++ b/packages/electron/src/renderer/workspace.css
@@ -1006,8 +1006,13 @@ html, body {
 .preferences-content {
   flex: 1;
   overflow-y: auto;
+  scrollbar-width: none;
   padding: 0;
   background-color: var(--md-bg-secondary);
+}
+
+.preferences-content::-webkit-scrollbar {
+  display: none;
 }
 
 /* Category header — centered at top of content area */

--- a/packages/electron/src/renderer/workspace.css
+++ b/packages/electron/src/renderer/workspace.css
@@ -914,38 +914,6 @@ html, body {
   background-color: var(--md-link);
 }
 
-/* About modal */
-.mdreview-about-modal {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(0, 0, 0, 0.4);
-  z-index: 9999;
-}
-
-.mdreview-about-card {
-  background-color: var(--md-bg);
-  border: 1px solid var(--md-border);
-  border-radius: 12px;
-  padding: 32px;
-  max-width: 360px;
-  text-align: center;
-  box-shadow: 0 8px 32px var(--md-shadow);
-}
-
-.mdreview-about-card h2 {
-  margin: 0 0 8px;
-  font-size: 20px;
-  color: var(--md-fg);
-}
-
-.mdreview-about-card p {
-  margin: 4px 0;
-  font-size: 13px;
-  color: var(--md-fg-muted);
-}
 
 /* Preferences panel — macOS System Settings layout */
 .preferences-panel,

--- a/packages/electron/src/shared/ipc-channels.ts
+++ b/packages/electron/src/shared/ipc-channels.ts
@@ -35,6 +35,10 @@ export const IPC_CHANNELS = {
   SET_OPEN_FOLDER: 'mdreview:set-open-folder',
   OPEN_EXTERNAL: 'mdreview:open-external',
 
+  // Context menu
+  SHOW_CONTEXT_MENU: 'mdreview:show-context-menu',
+  REVEAL_IN_FINDER: 'mdreview:reveal-in-finder',
+
   // Directory
   LIST_DIRECTORY: 'mdreview:list-directory',
   WATCH_DIRECTORY: 'mdreview:watch-directory',

--- a/packages/electron/src/shared/preload-api.ts
+++ b/packages/electron/src/shared/preload-api.ts
@@ -65,6 +65,14 @@ export interface MdreviewPreloadAPI {
   setOpenFolder(path: string | null): Promise<void>;
   openExternal(url: string): Promise<void>;
 
+  // Context menu
+  showContextMenu(context: {
+    hasSelection: boolean;
+    selectionText: string;
+    filePath: string;
+  }): Promise<void>;
+  revealInFinder(path: string): Promise<void>;
+
   // Tab groups
   createTabGroup(name: string, color: TabGroupColor, tabIds: string[]): Promise<TabGroupState>;
   updateTabGroup(


### PR DESCRIPTION
## Summary

- **Native About panel**: Replace custom HTML modal with macOS `setAboutPanelOptions()` for consistent platform UX
- **App protocol + context menu + file tree**: Register `app://` protocol for secure renderer origin (enables web workers), add native right-click context menu with copy/comment/reveal/search actions, implement lazy directory expansion in sidebar
- **Fix mermaid DOCX export**: Add missing `renderAllImmediate()` call and narrow SVG query from `'svg'` to `'.mermaid-container svg'` so diagrams are no longer silently dropped from Electron DOCX exports
- **Export regression tests**: 33 new tests across 4 files — end-to-end DOCX pipeline integration tests (JSZip verification of `document.xml`), ExportController unit tests, SVGConverter unit tests, and expanded ContentCollector regression tests
- **Chrome native host**: Native messaging host enabling the extension to write comment annotations back to source files on disk

## Test plan

- [x] `bun run test:ci` — all 1715 tests pass
- [x] Lint passes (pre-commit hooks)
- [ ] Manual: open a markdown file with mermaid diagrams in Electron, export to DOCX, verify diagrams appear
- [ ] Manual: right-click in document, verify context menu actions work
- [ ] Manual: expand directories in sidebar file tree