### PR TITLE
fix(core): render tables with mismatched separator column counts

### DIFF
--- a/packages/core/src/markdown-converter.ts
+++ b/packages/core/src/markdown-converter.ts
@@ -249,8 +249,11 @@ export class MarkdownConverter {
       // Calculate word count
       this.metadata.wordCount = markdown.trim().split(/\s+/).length;
 
+      // Preprocess: fix malformed GFM tables (column count mismatches)
+      const preprocessed = MarkdownConverter.fixTableSeparators(markdown);
+
       // Parse and render
-      const html = this.md.render(markdown);
+      const html = this.md.render(preprocessed);
 
       return {
         html,
@@ -312,6 +315,52 @@ export class MarkdownConverter {
   /**
    * Escape HTML for safe rendering
    */
+  /**
+   * Fix GFM table separator rows whose column count doesn't match the
+   * header row.  markdown-it (correctly per spec) rejects tables where the
+   * separator has a different number of columns than the header, but many
+   * LLM-generated and hand-edited files produce this pattern.  We
+   * normalise the separator to match the header so the table still renders.
+   */
+  static fixTableSeparators(markdown: string): string {
+    const lines = markdown.split('\n');
+    const result: string[] = [];
+    let inCodeFence = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Track fenced code blocks
+      if (/^(`{3,}|~{3,})/.test(line)) {
+        inCodeFence = !inCodeFence;
+      }
+
+      if (
+        !inCodeFence &&
+        i > 0 &&
+        /^\|[\s:]*-{1,}[\s:|-]*\|?\s*$/.test(line) // separator-looking line
+      ) {
+        const headerLine = lines[i - 1];
+        // Only fix if the previous line looks like a table header
+        if (/^\|.+\|/.test(headerLine)) {
+          const headerCols = headerLine.split('|').filter((c) => c.trim() !== '').length;
+          const sepCols = line.split('|').filter((c) => c.trim() !== '').length;
+
+          if (sepCols !== headerCols && headerCols > 0) {
+            // Rebuild separator with the correct column count
+            const sep = '| ' + Array(headerCols).fill('---').join(' | ') + ' |';
+            result.push(sep);
+            continue;
+          }
+        }
+      }
+
+      result.push(line);
+    }
+
+    return result.join('\n');
+  }
+
   private escapeHtml(text: string): string {
     const map: { [key: string]: string } = {
       '&': '&amp;',

--- a/tests/unit/core/markdown-converter.test.ts
+++ b/tests/unit/core/markdown-converter.test.ts
@@ -97,6 +97,39 @@ describe('MarkdownConverter', () => {
       expect(result.html).toContain('<tbody>');
     });
 
+    test('should render tables with mismatched separator column count', async () => {
+      // Regression: LLM-generated tables often have more separator columns than header columns
+      const md =
+        '| Parameter | Value | Default | Rationale |\n| --- | --- | --- | --- | --- | --- |\n| `stripe_size` | 131072 | 16384 | 8x default |';
+      const result = await converter.convert(md);
+      expect(result.html).toContain('<table>');
+      expect(result.html).toContain('<thead>');
+      expect(result.html).toContain('<td>');
+      expect(result.html).toContain('131072');
+    });
+
+    test('should render tables with fewer separator columns than header', async () => {
+      const md = '| A | B | C |\n| --- | --- |\n| 1 | 2 | 3 |';
+      const result = await converter.convert(md);
+      expect(result.html).toContain('<table>');
+      expect(result.html).toContain('<th>A</th>');
+    });
+
+    test('should not break correctly formed tables', async () => {
+      const md = '| A | B |\n| --- | --- |\n| 1 | 2 |';
+      const result = await converter.convert(md);
+      expect(result.html).toContain('<table>');
+      expect(result.html).toContain('<td>1</td>');
+    });
+
+    test('should not fix separators inside code fences', async () => {
+      const md = '```\n| A | B |\n| --- | --- | --- |\n| 1 | 2 |\n```';
+      const result = await converter.convert(md);
+      // Should be rendered as code, not a table
+      expect(result.html).not.toContain('<table>');
+      expect(result.html).toContain('<code>');
+    });
+
     test('should render task lists with checkboxes', async () => {
       const result = await converter.convert(markdownSamples.taskList);
       // Task lists should have checkboxes
@@ -337,5 +370,39 @@ describe('MarkdownConverter', () => {
       expect(result.metadata.links.length).toBeGreaterThan(0);
       expect(result.metadata.wordCount).toBeGreaterThan(0);
     });
+  });
+});
+
+describe('MarkdownConverter.fixTableSeparators', () => {
+  test('normalises separator with too many columns', () => {
+    const input = '| A | B |\n| --- | --- | --- | --- |\n| 1 | 2 |';
+    const fixed = MarkdownConverter.fixTableSeparators(input);
+    expect(fixed).toBe('| A | B |\n| --- | --- |\n| 1 | 2 |');
+  });
+
+  test('normalises separator with too few columns', () => {
+    const input = '| A | B | C |\n| --- |\n| 1 | 2 | 3 |';
+    const fixed = MarkdownConverter.fixTableSeparators(input);
+    expect(fixed).toBe('| A | B | C |\n| --- | --- | --- |\n| 1 | 2 | 3 |');
+  });
+
+  test('leaves correct separators unchanged', () => {
+    const input = '| A | B |\n| --- | --- |\n| 1 | 2 |';
+    const fixed = MarkdownConverter.fixTableSeparators(input);
+    expect(fixed).toBe(input);
+  });
+
+  test('does not modify separators inside code fences', () => {
+    const input = '```\n| A | B |\n| --- | --- | --- |\n| 1 | 2 |\n```';
+    const fixed = MarkdownConverter.fixTableSeparators(input);
+    expect(fixed).toBe(input);
+  });
+
+  test('handles multiple tables in one document', () => {
+    const input =
+      '| A | B |\n| --- | --- | --- |\n| 1 | 2 |\n\n| X | Y | Z |\n| --- |\n| a | b | c |';
+    const fixed = MarkdownConverter.fixTableSeparators(input);
+    expect(fixed).toContain('| --- | --- |');
+    expect(fixed).toContain('| --- | --- | --- |');
   });
 });


### PR DESCRIPTION
## Summary

Fixes a table rendering bug affecting both the Chrome extension and Electron app where GFM tables with mismatched separator column counts render as raw pipe-delimited text instead of HTML tables.

### Root cause

The GFM table spec requires the separator row (`| --- | --- |`) to have the same number of columns as the header row. Many LLM-generated and hand-edited markdown files produce separators with extra columns, e.g.:

```markdown
| Parameter | Value | Default | Rationale |
| --- | --- | --- | --- | --- | --- |
| `stripe_size` | 131072 | 16384 | 8x default |
```

Here the header has 4 columns but the separator has 6. markdown-it correctly rejects this per spec, treating the lines as a paragraph. The typographer then converts `---` to em dashes (`—`), making the table completely unreadable.

### Fix

Added `MarkdownConverter.fixTableSeparators()` — a preprocessing step that normalises separator column counts to match the header before passing markdown to the parser. The fix:

- Detects separator lines following pipe-delimited header lines
- Rebuilds the separator with the correct column count when mismatched
- Is code-fence-aware (won't modify tables inside code blocks)
- Handles multiple tables per document
- Leaves correctly formed tables unchanged

## Test plan

- [x] 9 new tests: 4 integration tests (converter renders mismatched tables) + 5 unit tests (fixTableSeparators static method)
- [x] All 1749 tests pass
- [ ] Manual: verify the RFC document tables render correctly in both Chrome extension and Electron