### PR TITLE
fix: increase bottom padding to prevent last line from being obscured

### DIFF
--- a/packages/core/styles/content.css
+++ b/packages/core/styles/content.css
@@ -71,6 +71,7 @@ body.mdreview-active {
   max-width: var(--md-max-width, 980px);
   margin: 0 auto;
   padding: 45px;
+  padding-bottom: 100px;
 }
 
 .mdreview-rendered {
@@ -1561,6 +1562,7 @@ body.mdreview-active.toc-visible-right .mdreview-toc-toggle-btn.position-right {
 @media (max-width: 768px) {
   #mdreview-container {
     padding: 20px;
+    padding-bottom: 80px;
   }
 
   .table-wrapper {

--- a/packages/electron/src/renderer/workspace.css
+++ b/packages/electron/src/renderer/workspace.css
@@ -743,6 +743,7 @@ html, body {
   max-width: var(--md-max-width, 980px);
   margin: 0 auto;
   padding: 45px;
+  padding-bottom: 100px;
   width: 100%;
   scrollbar-width: thin;
   scrollbar-color: var(--md-border) transparent;


### PR DESCRIPTION
## Summary
- Increases `padding-bottom` on content containers to prevent the last line of rendered markdown from being clipped at the bottom of the viewport
- Applied to Chrome extension (`#mdreview-container`), Electron (`.mdreview-tab-content`), and mobile responsive breakpoint

Closes #71