### PR TITLE
fix: sync sub-package versions via release-please extra-files

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,6 +7,11 @@
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        "packages/chrome-ext/package.json",
+        "packages/chrome-ext/public/manifest.json",
+        "packages/electron/package.json"
+      ],
       "changelog-sections": [
         {"type": "feat", "section": "Features"},
         {"type": "fix", "section": "Bug Fixes"},

--- a/packages/chrome-ext/package.json
+++ b/packages/chrome-ext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdreview/chrome-ext",
-  "version": "0.3.4",
+  "version": "0.3.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/chrome-ext/public/manifest.json
+++ b/packages/chrome-ext/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Design Review",
-  "version": "0.3.4",
+  "version": "0.3.9",
   "description": "An app for design review of software projects",
   "permissions": [
     "storage",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdreview/electron",
-  "version": "0.0.1",
+  "version": "0.3.9",
   "description": "Electron desktop viewer for mdreview",
   "type": "module",
   "private": true,


### PR DESCRIPTION
## Summary
- Adds `extra-files` to `.release-please-config.json` so release-please bumps versions in all sub-packages
- Syncs `packages/chrome-ext/package.json`, `packages/chrome-ext/public/manifest.json`, and `packages/electron/package.json` to current version (0.3.9)

Closes #73