### PR TITLE
Publish @mdreview/core to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # @mdreview/core's exports now point at dist/, so consumer packages
+      # (chrome-ext, electron) need dist/*.d.ts to exist before tsc/eslint
+      # can resolve its types. Without this step lint collapses into ~536
+      # @typescript-eslint/no-unsafe-* errors because the types fall back
+      # to `any`.
+      - name: Build @mdreview/core
+        run: bun run --cwd packages/core build
+
       - name: Run ESLint
         run: bun run lint
 

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -1,5 +1,22 @@
 name: Publish @mdreview/core
 
+# One-time npm setup required before this workflow can successfully publish:
+#
+#   1. Perform a manual `npm publish` from a maintainer machine to create the
+#      @mdreview/core package on npmjs.org (first publish cannot be provenanced
+#      because the package doesn't exist yet).
+#   2. Visit https://www.npmjs.com/package/@mdreview/core/access (or the
+#      org-level page https://www.npmjs.com/settings/mdreview/packages).
+#   3. Add a GitHub Actions Trusted Publisher with:
+#        Organization: yaklabco
+#        Repository:   mdreview
+#        Workflow:     .github/workflows/publish-core.yml
+#        Environment:  (leave blank)
+#
+# After that is configured, every subsequent publish on `core-v*` tags will
+# mint an OIDC token that npm verifies for auth and for provenance signing.
+# No NPM_TOKEN secret is required.
+
 on:
   push:
     tags:
@@ -35,8 +52,6 @@ jobs:
       - name: Test @mdreview/core
         run: bun run --cwd packages/core test:ci
 
-      - name: Publish to npm
+      - name: Publish to npm (OIDC + provenance)
         working-directory: packages/core
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -26,6 +26,10 @@ permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: publish-core-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish to npm

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -1,0 +1,42 @@
+name: Publish @mdreview/core
+
+on:
+  push:
+    tags:
+      - 'core-v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build @mdreview/core
+        run: bun run --cwd packages/core build
+
+      - name: Test @mdreview/core
+        run: bun run --cwd packages/core test:ci
+
+      - name: Publish to npm
+        working-directory: packages/core
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # @mdreview/core now publishes via dist/; its consumers in the workspace
+      # (chrome-ext, electron) need dist/*.d.ts before tsc/eslint can resolve
+      # its types. Without this step, lint collapses into ~536
+      # @typescript-eslint/no-unsafe-* errors. Mirrors ci.yml.
+      - name: Build @mdreview/core
+        run: bun run --cwd packages/core build
+
       - name: Run linter
         run: bun run lint
 

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -22,6 +22,25 @@
         {"type": "build", "section": "Build System"},
         {"type": "ci", "section": "Continuous Integration"}
       ]
+    },
+    "packages/core": {
+      "release-type": "node",
+      "component": "core",
+      "package-name": "@mdreview/core",
+      "include-component-in-tag": true,
+      "include-v-in-tag": true,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "refactor", "section": "Code Refactoring"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "test", "section": "Tests", "hidden": false},
+        {"type": "build", "section": "Build System"},
+        {"type": "ci", "section": "Continuous Integration"}
+      ]
     }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/chrome-ext": {
       "name": "@mdreview/chrome-ext",
-      "version": "0.3.4",
+      "version": "0.3.11",
       "dependencies": {
         "@mdreview/core": "workspace:*",
       },
@@ -72,11 +72,12 @@
         "@types/dompurify": "^3.0.5",
         "@types/markdown-it": "^13.0.9",
         "jszip": "^3.10.1",
+        "tsup": "^8",
       },
     },
     "packages/electron": {
       "name": "@mdreview/electron",
-      "version": "0.0.1",
+      "version": "0.3.11",
       "dependencies": {
         "@mdreview/core": "workspace:*",
         "chokidar": "^4.0.3",
@@ -733,6 +734,8 @@
 
     "builder-util-runtime": ["builder-util-runtime@9.5.1", "", { "dependencies": { "debug": "^4.3.4", "sax": "^1.2.4" } }, "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ=="],
 
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "cacache": ["cacache@19.0.1", "", { "dependencies": { "@npmcli/fs": "^4.0.0", "fs-minipass": "^3.0.0", "glob": "^10.2.2", "lru-cache": "^10.0.1", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^12.0.0", "tar": "^7.4.3", "unique-filename": "^4.0.0" } }, "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ=="],
@@ -802,6 +805,8 @@
     "conf": ["conf@15.1.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "atomically": "^2.0.3", "debounce-fn": "^6.0.0", "dot-prop": "^10.0.0", "env-paths": "^3.0.0", "json-schema-typed": "^8.0.1", "semver": "^7.7.2", "uint8array-extras": "^1.5.0" } }, "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og=="],
 
     "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
     "convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
 
@@ -1087,6 +1092,8 @@
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
     "flat-cache": ["flat-cache@3.2.0", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.3", "rimraf": "^3.0.2" } }, "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
@@ -1237,6 +1244,8 @@
 
     "jotai": ["jotai@2.18.1", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-e0NOzK+yRFwHo7DOp0DS0Ycq74KMEAObDWFGmfEL28PD9nLqBTt3/Ug7jf9ca72x0gC9LQZG9zH+0ISICmy3iA=="],
 
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -1288,6 +1297,8 @@
     "lint-staged": ["lint-staged@16.4.0", "", { "dependencies": { "commander": "^14.0.3", "listr2": "^9.0.5", "picomatch": "^4.0.3", "string-argv": "^0.3.2", "tinyexec": "^1.0.4", "yaml": "^2.8.2" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw=="],
 
     "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
@@ -1583,7 +1594,7 @@
 
     "resolve-alpn": ["resolve-alpn@1.2.1", "", {}, "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="],
 
-    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -1659,7 +1670,7 @@
 
     "sonic-boom": ["sonic-boom@3.8.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg=="],
 
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -1765,6 +1776,8 @@
 
     "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
 
     "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
@@ -1774,6 +1787,8 @@
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
@@ -2011,11 +2026,15 @@
 
     "electron-winstaller/fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
+    "escodegen/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
+    "fix-dts-default-cjs-exports/rollup": ["rollup@4.59.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.1", "@rollup/rollup-android-arm64": "4.59.1", "@rollup/rollup-darwin-arm64": "4.59.1", "@rollup/rollup-darwin-x64": "4.59.1", "@rollup/rollup-freebsd-arm64": "4.59.1", "@rollup/rollup-freebsd-x64": "4.59.1", "@rollup/rollup-linux-arm-gnueabihf": "4.59.1", "@rollup/rollup-linux-arm-musleabihf": "4.59.1", "@rollup/rollup-linux-arm64-gnu": "4.59.1", "@rollup/rollup-linux-arm64-musl": "4.59.1", "@rollup/rollup-linux-loong64-gnu": "4.59.1", "@rollup/rollup-linux-loong64-musl": "4.59.1", "@rollup/rollup-linux-ppc64-gnu": "4.59.1", "@rollup/rollup-linux-ppc64-musl": "4.59.1", "@rollup/rollup-linux-riscv64-gnu": "4.59.1", "@rollup/rollup-linux-riscv64-musl": "4.59.1", "@rollup/rollup-linux-s390x-gnu": "4.59.1", "@rollup/rollup-linux-x64-gnu": "4.59.1", "@rollup/rollup-linux-x64-musl": "4.59.1", "@rollup/rollup-openbsd-x64": "4.59.1", "@rollup/rollup-openharmony-arm64": "4.59.1", "@rollup/rollup-win32-arm64-msvc": "4.59.1", "@rollup/rollup-win32-ia32-msvc": "4.59.1", "@rollup/rollup-win32-x64-gnu": "4.59.1", "@rollup/rollup-win32-x64-msvc": "4.59.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
@@ -2024,6 +2043,8 @@
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "iconv-corefoundation/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
+
+    "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
@@ -2071,6 +2092,8 @@
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
+    "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
@@ -2080,6 +2103,10 @@
     "temp/rimraf": ["rimraf@2.6.3", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA=="],
 
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
+
+    "tsup/rollup": ["rollup@4.59.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.1", "@rollup/rollup-android-arm64": "4.59.1", "@rollup/rollup-darwin-arm64": "4.59.1", "@rollup/rollup-darwin-x64": "4.59.1", "@rollup/rollup-freebsd-arm64": "4.59.1", "@rollup/rollup-freebsd-x64": "4.59.1", "@rollup/rollup-linux-arm-gnueabihf": "4.59.1", "@rollup/rollup-linux-arm-musleabihf": "4.59.1", "@rollup/rollup-linux-arm64-gnu": "4.59.1", "@rollup/rollup-linux-arm64-musl": "4.59.1", "@rollup/rollup-linux-loong64-gnu": "4.59.1", "@rollup/rollup-linux-loong64-musl": "4.59.1", "@rollup/rollup-linux-ppc64-gnu": "4.59.1", "@rollup/rollup-linux-ppc64-musl": "4.59.1", "@rollup/rollup-linux-riscv64-gnu": "4.59.1", "@rollup/rollup-linux-riscv64-musl": "4.59.1", "@rollup/rollup-linux-s390x-gnu": "4.59.1", "@rollup/rollup-linux-x64-gnu": "4.59.1", "@rollup/rollup-linux-x64-musl": "4.59.1", "@rollup/rollup-openbsd-x64": "4.59.1", "@rollup/rollup-openharmony-arm64": "4.59.1", "@rollup/rollup-win32-arm64-msvc": "4.59.1", "@rollup/rollup-win32-ia32-msvc": "4.59.1", "@rollup/rollup-win32-x64-gnu": "4.59.1", "@rollup/rollup-win32-x64-msvc": "4.59.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA=="],
+
+    "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "tsx/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -2213,6 +2240,8 @@
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "fix-dts-default-cjs-exports/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "iconv-corefoundation/cli-truncate/slice-ansi": ["slice-ansi@3.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ=="],
@@ -2244,6 +2273,8 @@
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "tailwindcss/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "tsup/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["tsup.config.ts"]
+}

--- a/packages/core/__smoke__/consumer.test.mjs
+++ b/packages/core/__smoke__/consumer.test.mjs
@@ -1,0 +1,33 @@
+/**
+ * Consumer smoke test for @mdreview/core's published tarball.
+ *
+ * Imports from ../dist/index.js (the same entry that `exports["."].import`
+ * points at) and exercises the MarkdownConverter barrel. If this file runs
+ * green after `bun run build`, the tarball that will land on npm contains
+ * a working runtime bundle.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MarkdownConverter } from '../dist/index.js';
+
+describe('@mdreview/core consumer smoke', () => {
+  it('renders a heading and a mermaid block from the dist bundle', () => {
+    const converter = new MarkdownConverter();
+    const markdown = [
+      '# Smoke Test Heading',
+      '',
+      '```mermaid',
+      'graph TD',
+      'A --> B',
+      '```',
+      '',
+    ].join('\n');
+
+    const result = converter.convert(markdown);
+
+    expect(result.errors).toEqual([]);
+    expect(result.html).toContain('<h1');
+    expect(result.html).toContain('mermaid');
+    expect(result.metadata.mermaidBlocks).toHaveLength(1);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,8 @@
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
     "@types/markdown-it": "^13.0.9",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "tsup": "^8"
   },
   "author": "James Ainslie",
   "license": "MIT"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@mdreview/core",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Core rendering engine for mdreview",
   "type": "module",
+  "files": [
+    "dist",
+    "styles"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "import": "./dist/index.js",
@@ -29,7 +36,8 @@
   "scripts": {
     "build": "tsup",
     "test": "vitest",
-    "test:ci": "vitest --run"
+    "test:ci": "vitest --run",
+    "prepublishOnly": "bun run build && bun run test:ci"
   },
   "dependencies": {
     "@jamesainslie/docx": "^9.5.1-svg.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,5 +59,8 @@
     "tsup": "^8"
   },
   "author": "James Ainslie",
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "./styles/content.css": "./styles/content.css"
   },
   "scripts": {
-    "build": "echo 'Core uses source exports, no build needed'",
+    "build": "tsup",
     "test": "vitest",
     "test:ci": "vitest --run"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,24 +12,24 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./node": {
-      "import": "./dist/node.js",
-      "types": "./dist/node.d.ts"
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js"
     },
     "./sw": {
-      "import": "./dist/sw.js",
-      "types": "./dist/sw.d.ts"
+      "types": "./dist/sw.d.ts",
+      "import": "./dist/sw.js"
     },
     "./adapters": {
-      "import": "./dist/adapters.js",
-      "types": "./dist/adapters.d.ts"
+      "types": "./dist/adapters.d.ts",
+      "import": "./dist/adapters.js"
     },
     "./utils/debug-logger": {
-      "import": "./dist/utils/debug-logger.js",
-      "types": "./dist/utils/debug-logger.d.ts"
+      "types": "./dist/utils/debug-logger.d.ts",
+      "import": "./dist/utils/debug-logger.js"
     },
     "./styles/content.css": "./styles/content.css"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,11 +4,26 @@
   "description": "Core rendering engine for mdreview",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./node": "./src/node.ts",
-    "./sw": "./src/sw.ts",
-    "./utils/debug-logger": "./src/utils/debug-logger.ts",
-    "./adapters": "./src/adapters.ts",
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./node": {
+      "import": "./dist/node.js",
+      "types": "./dist/node.d.ts"
+    },
+    "./sw": {
+      "import": "./dist/sw.js",
+      "types": "./dist/sw.d.ts"
+    },
+    "./adapters": {
+      "import": "./dist/adapters.js",
+      "types": "./dist/adapters.d.ts"
+    },
+    "./utils/debug-logger": {
+      "import": "./dist/utils/debug-logger.js",
+      "types": "./dist/utils/debug-logger.d.ts"
+    },
     "./styles/content.css": "./styles/content.css"
   },
   "scripts": {

--- a/packages/core/src/__tests__/barrel-export.test.ts
+++ b/packages/core/src/__tests__/barrel-export.test.ts
@@ -57,7 +57,7 @@ import {
 
 describe('@mdreview/core barrel export', () => {
   it('exports VERSION', () => {
-    expect(VERSION).toBe('0.0.1');
+    expect(VERSION).toBe('0.1.0');
   });
 
   it('exports all 8 themes', () => {

--- a/packages/core/src/__tests__/smoke.test.ts
+++ b/packages/core/src/__tests__/smoke.test.ts
@@ -2,6 +2,6 @@ import { VERSION } from '../index';
 
 describe('@mdreview/core', () => {
   it('should export VERSION', () => {
-    expect(VERSION).toBe('0.0.1');
+    expect(VERSION).toBe('0.1.0');
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 // @mdreview/core - shared rendering engine
-export const VERSION = '0.0.1';
+export const VERSION = '0.1.0';
 
 // Types
 export type * from './types/index';

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1,7 +1,7 @@
 // @mdreview/core/node - lightweight entry point for Node.js (Electron main process)
 // Excludes browser-only modules (workers, mermaid, DOM renderers)
 
-export const VERSION = '0.0.1';
+export const VERSION = '0.1.0';
 
 // Types
 export type * from './types/index';

--- a/packages/core/src/types/index.d.ts
+++ b/packages/core/src/types/index.d.ts
@@ -77,6 +77,13 @@ export interface AppState {
   };
 }
 
+/**
+ * User preferences extracted from AppState. Exposed as a named alias so
+ * downstream consumers (service workers, embedders) can import `Preferences`
+ * directly instead of reaching through `AppState['preferences']`.
+ */
+export type Preferences = AppState['preferences'];
+
 export interface Theme {
   name: ThemeName;
   displayName: string;
@@ -494,10 +501,10 @@ export type FilenameTemplateVar =
  * A reply within a comment thread
  */
 export interface CommentReply {
-  id: string;        // "reply-1", "reply-2", scoped within parent
+  id: string; // "reply-1", "reply-2", scoped within parent
   author: string;
   body: string;
-  date: string;      // ISO 8601
+  date: string; // ISO 8601
 }
 
 /**
@@ -508,14 +515,7 @@ export type CommentReactions = Record<string, string[]>;
 /**
  * Tag that can be applied to a comment to signal severity/intent.
  */
-export type CommentTag =
-  | 'blocking'
-  | 'nit'
-  | 'suggestion'
-  | 'question'
-  | 'praise'
-  | 'todo'
-  | 'fyi';
+export type CommentTag = 'blocking' | 'nit' | 'suggestion' | 'question' | 'praise' | 'todo' | 'fyi';
 
 /**
  * Positional context for a comment within the document structure.

--- a/packages/core/src/types/vite-worker.d.ts
+++ b/packages/core/src/types/vite-worker.d.ts
@@ -1,0 +1,17 @@
+// Type declarations for Vite worker imports (`?worker` suffix).
+// These modules are provided by the bundler at runtime; the constructor
+// returns a standard `Worker` instance.
+
+declare module '*?worker' {
+  const WorkerConstructor: {
+    new (options?: { name?: string }): Worker;
+  };
+  export default WorkerConstructor;
+}
+
+declare module '*?worker&inline' {
+  const WorkerConstructor: {
+    new (options?: { name?: string }): Worker;
+  };
+  export default WorkerConstructor;
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
     "rootDir": "src",
     "baseUrl": ".",
     "paths": {},

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   },
   format: ["esm"],
   dts: true,
-  sourcemap: true,
+  sourcemap: "inline",
   clean: true,
   target: "es2022",
   outDir: "dist",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    node: "src/node.ts",
+    sw: "src/sw.ts",
+    adapters: "src/adapters.ts",
+    "utils/debug-logger": "src/utils/debug-logger.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  target: "es2022",
+  outDir: "dist",
+  external: [
+    "markdown-it",
+    "markdown-it-anchor",
+    "markdown-it-attrs",
+    "markdown-it-emoji",
+    "markdown-it-footnote",
+    "markdown-it-task-lists",
+    "mermaid",
+    "panzoom",
+    "highlight.js",
+    "dompurify",
+    "@jamesainslie/docx",
+  ],
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     testTimeout: 10000,
+    // Include default src tests + the __smoke__ consumer test that exercises
+    // the built dist/ tarball to guard against broken publishes.
+    include: [
+      'src/**/*.{test,spec}.?(c|m)[jt]s?(x)',
+      '__smoke__/**/*.test.?(c|m)[jt]s?(x)',
+    ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,19 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './packages/chrome-ext/src'),
+      // Keep `@mdreview/core` resolving to source while the published
+      // package ships `dist/`. Existing tests mock relative paths under
+      // `packages/core/src/...`, and those mocks only intercept when the
+      // importing module also resolves through the same source files.
+      // Subpath aliases mirror the subpath exports in packages/core/package.json.
+      '@mdreview/core/node': resolve(__dirname, './packages/core/src/node.ts'),
+      '@mdreview/core/sw': resolve(__dirname, './packages/core/src/sw.ts'),
+      '@mdreview/core/adapters': resolve(__dirname, './packages/core/src/adapters.ts'),
+      '@mdreview/core/utils/debug-logger': resolve(
+        __dirname,
+        './packages/core/src/utils/debug-logger.ts'
+      ),
+      '@mdreview/core': resolve(__dirname, './packages/core/src/index.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

Phase A of the two-phase work that makes `@mdreview/core` installable from npm. Phase B (downstream consumption) happens in a separate repo once `0.1.0` is published.

### What changed

- **tsup build pipeline.** `packages/core` now ships a real ESM bundle under `dist/` instead of re-exporting TypeScript sources. `tsup.config.ts` pins ESM-only output, emits `.d.ts` + sourcemaps, and externalises the heavy runtime deps (markdown-it plugins, mermaid, panzoom, highlight.js, DOMPurify, docx).
- **Exports flipped.** Each subpath in `package.json#exports` now resolves to a dual `{ import, types }` pair under `dist/`. `styles/content.css` still points at source because CSS isn't part of the tsup bundle. Root `vitest.config.ts` gets matching aliases so existing tests that mock relative paths under `packages/core/src/...` keep working in the test environment.
- **Publish metadata.** Version bumped to `0.1.0` (first published release). Added `files: ["dist", "styles"]`, `publishConfig.access: "public"`, and a `prepublishOnly` gate that runs `build && test:ci`.
- **Consumer smoke test.** `packages/core/__smoke__/consumer.test.mjs` imports from `../dist/index.js` and renders a markdown fixture containing a mermaid code block, asserting the output contains `<h1` and `mermaid`.
- **Release-please.** New managed entry for `packages/core` with `release-type: node`, `component: core`, `package-name: @mdreview/core`. Tags will be `core-v<version>`.
- **Publish workflow.** `.github/workflows/publish-core.yml` triggers on `core-v*` tags, rebuilds, re-tests, and `npm publish --access public` using the `NPM_TOKEN` secret.

### Supporting fixes

- Exported the `Preferences` type alias (was inline in `AppState`) so `sw.ts`'s re-export resolves during dts generation.
- Removed `composite: true` from `packages/core/tsconfig.json` so tsup's dts worker can traverse imports without TS6307.
- Added a `*?worker` ambient declaration so the Vite virtual import in `worker-pool.ts` type-checks.
- Local `packages/core/.eslintrc.json` ignores `tsup.config.ts` since it lives outside the TS project.

## Verification

- `bun run --cwd packages/core build` -> success, all expected outputs present under `dist/`.
- `bun run --cwd packages/core test:ci` -> 322 tests passed (was 321, +1 smoke test).
- `bun run test:ci` (root) -> 1750 tests passed.
- `bun run lint` -> 0 errors (99 pre-existing warnings untouched).
- `npm publish --dry-run` inside `packages/core/` -> tarball contains `dist/` + `styles/` + `package.json` only.

## Test plan

- [ ] CI lint + test passes on this branch
- [ ] After merge, release-please opens a release PR for `core` when the next conventional commit lands under `packages/core/`
- [ ] Tagging `core-v0.1.0` triggers `.github/workflows/publish-core.yml` and publishes to npm (requires `NPM_TOKEN` repo secret)