### PR TITLE
fix(ci): replace retired macOS x64 runner

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -91,7 +91,7 @@ jobs:
               packages/electron/dist/*.dmg
               packages/electron/dist/*.zip
           - name: macOS (x64)
-            os: macos-13
+            os: macos-15-intel
             dist-cmd: dist:mac
             artifact-name: electron-mac-x64
             artifact-path: |


### PR DESCRIPTION
## Summary
- Replace the retired `macos-13` release runner with `macos-15-intel` for Electron x64 builds.
- Prevent release workflows from stalling indefinitely while waiting for unavailable macOS 13 capacity.

## Test plan
- `bun run test:ci` passed via pre-push hook: 96 files, 1881 tests.
- Release pipeline will validate on merge.