### PR TITLE
feat(logging): shared OTEL-shaped logging infrastructure (Phase 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,20 +43,23 @@
     },
     "packages/chrome-ext": {
       "name": "@mdreview/chrome-ext",
-      "version": "0.3.11",
+      "version": "0.3.13",
       "dependencies": {
         "@mdreview/core": "workspace:*",
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.28",
         "@types/chrome": "^0.0.287",
+        "fake-indexeddb": "^6.2.5",
       },
     },
     "packages/core": {
       "name": "@mdreview/core",
-      "version": "0.0.1",
+      "version": "0.3.0",
       "dependencies": {
         "@jamesainslie/docx": "^9.5.1-svg.1",
+        "@opentelemetry/api-logs": "^0.217.0",
+        "@opentelemetry/sdk-logs": "^0.217.0",
         "dompurify": "^3.0.6",
         "highlight.js": "^11.9.0",
         "markdown-it": "^14.1.0",
@@ -77,7 +80,7 @@
     },
     "packages/electron": {
       "name": "@mdreview/electron",
-      "version": "0.3.11",
+      "version": "0.3.13",
       "dependencies": {
         "@mdreview/core": "workspace:*",
         "chokidar": "^4.0.3",
@@ -372,6 +375,18 @@
     "@npmcli/agent": ["@npmcli/agent@3.0.0", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^10.0.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q=="],
 
     "@npmcli/fs": ["@npmcli/fs@4.0.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Cdq0jW2lknrNfrAm92MyEAvpe2cRsKjdnQLHUL6xRA4IVUnsWx6P65E7NcUO0Y+L4w1Aee5iV8FvjSwd+lrs9A=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.217.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.217.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-BB+PcHItcZDL63dPMW+mJvwN9rk37wuIDjRxbVlg6pPDvDR/7GL7UJHbGsllgoggOoTimsKgENaWPoGch/oE1A=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -1072,6 +1087,8 @@
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
     "extsprintf": ["extsprintf@1.4.1", "", {}, "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/packages/chrome-ext/package.json
+++ b/packages/chrome-ext/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.28",
-    "@types/chrome": "^0.0.287"
+    "@types/chrome": "^0.0.287",
+    "fake-indexeddb": "^6.2.5"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,8 @@
   },
   "dependencies": {
     "@jamesainslie/docx": "^9.5.1-svg.1",
+    "@opentelemetry/api-logs": "^0.217.0",
+    "@opentelemetry/sdk-logs": "^0.217.0",
     "dompurify": "^3.0.6",
     "highlight.js": "^11.9.0",
     "markdown-it": "^14.1.0",

--- a/packages/core/src/__tests__/adapters.test.ts
+++ b/packages/core/src/__tests__/adapters.test.ts
@@ -6,6 +6,7 @@ import {
   NoopExportAdapter,
   NoopGitAdapter,
   NoopBridgeHealth,
+  NoopLoggingAdapter,
   createNoopAdapters,
 } from '../adapters';
 import type {
@@ -216,6 +217,15 @@ describe('Platform Adapters', () => {
 
     it('onStateChange does not throw', () => {
       expect(() => health.onStateChange(() => {})).not.toThrow();
+    });
+  });
+
+  describe('NoopLoggingAdapter', () => {
+    it('builds with a noop transport and a valid resource', () => {
+      const a = new NoopLoggingAdapter();
+      const { transport, resource } = a.build();
+      expect(typeof transport.export).toBe('function');
+      expect(resource['service.name']).toBe('mdview');
     });
   });
 

--- a/packages/core/src/__tests__/logging/file-rotation.test.ts
+++ b/packages/core/src/__tests__/logging/file-rotation.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  currentFileName,
+  dateStem,
+  nextSizeSuffix,
+  planPrune,
+  planRotation,
+} from '../../logging/file-rotation';
+
+const d = (s: string) => new Date(`${s}T00:00:00.000Z`);
+
+describe('dateStem', () => {
+  it('returns YYYY-MM-DD in UTC', () => {
+    expect(dateStem(d('2026-05-11'))).toBe('2026-05-11');
+  });
+});
+
+describe('currentFileName', () => {
+  it('uses source and date stem', () => {
+    expect(currentFileName('electron', d('2026-05-11'))).toBe('mdview-electron-2026-05-11.jsonl');
+    expect(currentFileName('chrome', d('2026-05-11'))).toBe('mdview-chrome-2026-05-11.jsonl');
+  });
+});
+
+describe('planRotation', () => {
+  const opts = {
+    source: 'electron' as const,
+    today: d('2026-05-11'),
+    maxBytes: 1000,
+    retentionDays: 14,
+  };
+
+  it('appends to a fresh file when currentFile is null', () => {
+    expect(planRotation([], null, 0, 100, opts)).toEqual({
+      kind: 'append',
+      file: 'mdview-electron-2026-05-11.jsonl',
+    });
+  });
+
+  it('rolls over by date when current file is yesterday', () => {
+    const cur = 'mdview-electron-2026-05-10.jsonl';
+    expect(planRotation([{ name: cur, size: 100 }], cur, 100, 50, opts)).toEqual({
+      kind: 'rollover-date',
+      from: cur,
+      to: 'mdview-electron-2026-05-11.jsonl',
+    });
+  });
+
+  it('rolls over by size when projected bytes exceed maxBytes', () => {
+    const cur = 'mdview-electron-2026-05-11.jsonl';
+    const action = planRotation([{ name: cur, size: 900 }], cur, 900, 200, opts);
+    expect(action).toEqual({
+      kind: 'rollover-size',
+      from: cur,
+      renameTo: `${cur}.1`,
+      to: cur,
+    });
+  });
+
+  it('picks the next unused size suffix on roll-over-size', () => {
+    const cur = 'mdview-electron-2026-05-11.jsonl';
+    const dir = [
+      { name: cur, size: 900 },
+      { name: `${cur}.1`, size: 999 },
+      { name: `${cur}.2`, size: 999 },
+    ];
+    const action = planRotation(dir, cur, 900, 200, opts);
+    expect(action).toEqual({
+      kind: 'rollover-size',
+      from: cur,
+      renameTo: `${cur}.3`,
+      to: cur,
+    });
+  });
+
+  it('appends when within size and date matches', () => {
+    const cur = 'mdview-electron-2026-05-11.jsonl';
+    expect(planRotation([{ name: cur, size: 100 }], cur, 100, 50, opts)).toEqual({
+      kind: 'append',
+      file: cur,
+    });
+  });
+});
+
+describe('nextSizeSuffix', () => {
+  it('returns 1 when there are no suffixed siblings', () => {
+    expect(nextSizeSuffix([], 'mdview-electron-2026-05-11.jsonl')).toBe(1);
+  });
+
+  it('skips gaps and returns lowest unused', () => {
+    const base = 'mdview-electron-2026-05-11.jsonl';
+    expect(
+      nextSizeSuffix(
+        [
+          { name: `${base}.1`, size: 0 },
+          { name: `${base}.3`, size: 0 },
+        ],
+        base
+      )
+    ).toBe(2);
+  });
+
+  it('handles sequential siblings', () => {
+    const base = 'mdview-electron-2026-05-11.jsonl';
+    expect(
+      nextSizeSuffix(
+        [
+          { name: `${base}.1`, size: 0 },
+          { name: `${base}.2`, size: 0 },
+          { name: `${base}.3`, size: 0 },
+        ],
+        base
+      )
+    ).toBe(4);
+  });
+});
+
+describe('planPrune', () => {
+  it('returns names whose date stem is older than today - retentionDays', () => {
+    const dir = [
+      { name: 'mdview-electron-2026-04-20.jsonl', size: 0 },
+      { name: 'mdview-electron-2026-04-26.jsonl', size: 0 },
+      { name: 'mdview-electron-2026-05-11.jsonl', size: 0 },
+      { name: 'mdview-electron-2026-04-27.jsonl.1', size: 0 },
+      { name: 'unrelated.txt', size: 0 },
+    ];
+    const out = planPrune(dir, {
+      today: d('2026-05-11'),
+      retentionDays: 14,
+      source: 'electron',
+    });
+    // cutoff = 2026-04-27; strictly older means < 2026-04-27
+    expect(out).toEqual(['mdview-electron-2026-04-20.jsonl', 'mdview-electron-2026-04-26.jsonl']);
+  });
+
+  it('ignores files from other sources', () => {
+    const dir = [
+      { name: 'mdview-electron-2026-04-20.jsonl', size: 0 },
+      { name: 'mdview-chrome-2026-04-20.jsonl', size: 0 },
+    ];
+    const out = planPrune(dir, {
+      today: d('2026-05-11'),
+      retentionDays: 14,
+      source: 'electron',
+    });
+    expect(out).toEqual(['mdview-electron-2026-04-20.jsonl']);
+  });
+
+  it('returns empty when nothing is old enough', () => {
+    const dir = [{ name: 'mdview-electron-2026-05-11.jsonl', size: 0 }];
+    expect(
+      planPrune(dir, { today: d('2026-05-11'), retentionDays: 14, source: 'electron' })
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/logging/index.test.ts
+++ b/packages/core/src/__tests__/logging/index.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getLogger, initLogging, shutdownLogging } from '../../logging';
+import type { LogRecord } from '../../logging/log-record';
+import type { LogTransport, TransportResult } from '../../logging/transport';
+
+class CollectingTransport implements LogTransport {
+  records: LogRecord[] = [];
+  export(records: readonly LogRecord[]): Promise<TransportResult> {
+    this.records.push(...records);
+    return Promise.resolve({ ok: true });
+  }
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+const RESOURCE = {
+  'service.name': 'mdview' as const,
+  'service.version': '0.0.0-test',
+  'service.namespace': 'electron-main' as const,
+  'deployment.environment': 'dev' as const,
+  'host.os': 'test',
+};
+
+afterEach(async () => {
+  await shutdownLogging();
+});
+
+describe('public surface', () => {
+  it('returns same logger instance from getLogger across calls', () => {
+    const a = getLogger('x');
+    const b = getLogger('x');
+    expect(a).toBe(b);
+  });
+
+  it('buffers records emitted before init and replays them on init', async () => {
+    const transport = new CollectingTransport();
+    const log = getLogger('boot');
+    log.info('one');
+    log.info('two', { k: 'v' });
+
+    initLogging({ transport, resource: RESOURCE, maxBatch: 1, flushIntervalMs: 9999 });
+
+    // After init the processor flushes synchronously due to maxBatch=1; allow microtasks to settle.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(transport.records.map((r) => r.body)).toEqual(['one', 'two']);
+    expect(transport.records[1].attributes.k).toBe('v');
+  });
+
+  it('post-init emits go directly to transport', async () => {
+    const transport = new CollectingTransport();
+    initLogging({ transport, resource: RESOURCE, maxBatch: 1, flushIntervalMs: 9999 });
+
+    const log = getLogger('post');
+    log.info('hello');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(transport.records).toHaveLength(1);
+    expect(transport.records[0].body).toBe('hello');
+    expect(transport.records[0].resource).toEqual(RESOURCE);
+  });
+
+  it('shutdown flushes and clears state; subsequent getLogger returns a fresh instance', async () => {
+    const transport = new CollectingTransport();
+    initLogging({ transport, resource: RESOURCE, maxBatch: 999, flushIntervalMs: 9999 });
+    const a = getLogger('y');
+    a.info('pending');
+    await shutdownLogging();
+    expect(transport.records.map((r) => r.body)).toEqual(['pending']);
+    const b = getLogger('y');
+    expect(b).not.toBe(a);
+  });
+
+  it('preserves logger identity across init', async () => {
+    const transport = new CollectingTransport();
+    const log = getLogger('keep-me');
+    initLogging({ transport, resource: RESOURCE, maxBatch: 1, flushIntervalMs: 9999 });
+    const same = getLogger('keep-me');
+    expect(same).toBe(log);
+    log.info('after');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(transport.records.map((r) => r.body)).toEqual(['after']);
+  });
+});

--- a/packages/core/src/__tests__/logging/log-record.test.ts
+++ b/packages/core/src/__tests__/logging/log-record.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { severityNumberFor, severityTextFor } from '../../logging/log-record';
+
+describe('severity mapping', () => {
+  it('maps each level to its OTEL number', () => {
+    expect(severityNumberFor('trace')).toBe(1);
+    expect(severityNumberFor('debug')).toBe(5);
+    expect(severityNumberFor('info')).toBe(9);
+    expect(severityNumberFor('warn')).toBe(13);
+    expect(severityNumberFor('error')).toBe(17);
+    expect(severityNumberFor('fatal')).toBe(21);
+  });
+  it('maps numbers back to text', () => {
+    expect(severityTextFor(9)).toBe('INFO');
+    expect(severityTextFor(17)).toBe('ERROR');
+  });
+});

--- a/packages/core/src/__tests__/logging/logger.test.ts
+++ b/packages/core/src/__tests__/logging/logger.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type { LogRecord, ResourceAttrs } from '../../logging/log-record';
+import { createLogger } from '../../logging/logger';
+
+const RESOURCE: ResourceAttrs = {
+  'service.name': 'mdview',
+  'service.version': '0.0.0-test',
+  'service.namespace': 'electron-main',
+  'deployment.environment': 'dev',
+  'host.os': 'test',
+};
+
+function setup(opts: Partial<{ now: () => number; idSeed: number }> = {}) {
+  const records: LogRecord[] = [];
+  let seed = opts.idSeed ?? 1;
+  const logger = createLogger({
+    emit: (r) => records.push(r),
+    resource: RESOURCE,
+    now: opts.now ?? (() => 1_700_000_000_000),
+    randomBytes: (n: number) => {
+      // deterministic: ascending bytes from seed
+      const out = new Uint8Array(n);
+      for (let i = 0; i < n; i++) {
+        out[i] = seed++ & 0xff;
+      }
+      return out;
+    },
+  });
+  return { logger, records };
+}
+
+describe('Logger basic emit', () => {
+  it('emits a record with severityNumber, body, attributes, resource', () => {
+    const { logger, records } = setup();
+    logger.info('hello', { a: 1 });
+    expect(records).toHaveLength(1);
+    const r = records[0];
+    expect(r.severityNumber).toBe(9);
+    expect(r.severityText).toBe('INFO');
+    expect(r.body).toBe('hello');
+    expect(r.attributes.a).toBe(1);
+    expect(r.resource).toEqual(RESOURCE);
+    expect(r.timestamp).toBe(1_700_000_000_000 * 1_000_000);
+  });
+
+  it('lifts exception attrs from an Error on error()', () => {
+    const { logger, records } = setup();
+    const err = new TypeError('bad');
+    err.stack = 'STACK';
+    logger.error('boom', { ctx: 'x' }, err);
+    expect(records[0].attributes['exception.type']).toBe('TypeError');
+    expect(records[0].attributes['exception.message']).toBe('bad');
+    expect(records[0].attributes['exception.stacktrace']).toBe('STACK');
+    expect(records[0].attributes.ctx).toBe('x');
+    expect(records[0].severityNumber).toBe(17);
+  });
+
+  it('caller-provided exception attrs win over lifted ones', () => {
+    const { logger, records } = setup();
+    logger.error('x', { 'exception.message': 'override' }, new Error('orig'));
+    expect(records[0].attributes['exception.message']).toBe('override');
+  });
+});
+
+describe('Logger child', () => {
+  it('records code.namespace from child name', () => {
+    const { logger, records } = setup();
+    logger.child('comments').info('x');
+    expect(records[0].attributes['code.namespace']).toBe('comments');
+  });
+
+  it('dot-joins nested namespaces', () => {
+    const { logger, records } = setup();
+    logger.child('comments').child('ui').info('x');
+    expect(records[0].attributes['code.namespace']).toBe('comments.ui');
+  });
+
+  it('child inherits and merges base attrs (call-site wins)', () => {
+    const { logger, records } = setup();
+    const c = logger.child('comments', { a: 1, b: 2 });
+    c.info('x', { b: 99 });
+    expect(records[0].attributes.a).toBe(1);
+    expect(records[0].attributes.b).toBe(99);
+  });
+});
+
+describe('Logger withSpan (sync)', () => {
+  it('emits start and end sharing traceId/spanId, with duration_ns', () => {
+    let t = 1_700_000_000_000;
+    const { logger, records } = setup({ now: () => t });
+    const out = logger.withSpan('comment.add', (span) => {
+      t += 50;
+      span.setAttribute('mdview.comment.id', 'c1');
+      return 'done';
+    });
+    expect(out).toBe('done');
+    expect(records).toHaveLength(2);
+    expect(records[0].body).toBe('comment.add.start');
+    expect(records[1].body).toBe('comment.add.end');
+    expect(records[0].traceId).toBe(records[1].traceId);
+    expect(records[0].spanId).toBe(records[1].spanId);
+    expect((records[0].traceId ?? '').length).toBe(32);
+    expect((records[0].spanId ?? '').length).toBe(16);
+    expect(records[1].attributes['duration_ns']).toBe(50 * 1_000_000);
+    expect(records[1].attributes['mdview.span.status']).toBe('ok');
+    expect(records[1].attributes['mdview.comment.id']).toBe('c1');
+  });
+
+  it('records exception event + error status on throw, then rethrows', () => {
+    const { logger, records } = setup();
+    const fail = new Error('boom');
+    expect(() =>
+      logger.withSpan('op', () => {
+        throw fail;
+      })
+    ).toThrow('boom');
+    expect(records.map((r) => r.body)).toEqual(['op.start', 'exception', 'op.end']);
+    expect(records[1].attributes['exception.message']).toBe('boom');
+    expect(records[2].attributes['mdview.span.status']).toBe('error');
+  });
+});
+
+describe('Logger withSpan (async)', () => {
+  it('handles async fn with successful resolution', async () => {
+    const { logger, records } = setup();
+    const out = await logger.withSpan('op', () => Promise.resolve('ok'));
+    expect(out).toBe('ok');
+    expect(records).toHaveLength(2);
+    expect(records[1].attributes['mdview.span.status']).toBe('ok');
+  });
+
+  it('handles async rejection: exception event + error status + rethrow', async () => {
+    const { logger, records } = setup();
+    const p = logger.withSpan('op', () => Promise.reject(new Error('async-boom')));
+    await expect(p).rejects.toThrow('async-boom');
+    expect(records.map((r) => r.body)).toEqual(['op.start', 'exception', 'op.end']);
+    expect(records[2].attributes['mdview.span.status']).toBe('error');
+  });
+
+  it('addEvent emits a record with the span trace/span ids', () => {
+    const { logger, records } = setup();
+    logger.withSpan('op', (span) => {
+      span.addEvent('checkpoint', { k: 'v' });
+    });
+    expect(records.map((r) => r.body)).toEqual(['op.start', 'checkpoint', 'op.end']);
+    expect(records[1].attributes.k).toBe('v');
+    expect(records[1].attributes['mdview.span.event']).toBe('checkpoint');
+    expect(records[1].traceId).toBe(records[0].traceId);
+    expect(records[1].spanId).toBe(records[0].spanId);
+  });
+});

--- a/packages/core/src/__tests__/logging/processor.test.ts
+++ b/packages/core/src/__tests__/logging/processor.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createProcessor } from '../../logging/processor';
+import type { LogRecord } from '../../logging/log-record';
+import type { LogTransport, TransportResult } from '../../logging/transport';
+
+function makeRecord(i: number): LogRecord {
+  return {
+    timestamp: i,
+    observedTimestamp: i,
+    severityNumber: 9,
+    severityText: 'INFO',
+    body: `msg-${i}`,
+    attributes: {},
+    resource: {
+      'service.name': 'mdview',
+      'service.version': '0.0.0-test',
+      'service.namespace': 'electron-main',
+      'deployment.environment': 'dev',
+      'host.os': 'test',
+    },
+  };
+}
+
+class StubTransport implements LogTransport {
+  calls: LogRecord[][] = [];
+  result: TransportResult = { ok: true };
+  shutdownCalled = false;
+  export(records: readonly LogRecord[]): Promise<TransportResult> {
+    this.calls.push([...records]);
+    return Promise.resolve(this.result);
+  }
+  shutdown(): Promise<void> {
+    this.shutdownCalled = true;
+    return Promise.resolve();
+  }
+}
+
+describe('BatchLogRecordProcessor', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('flushes when batch size reaches maxBatch', async () => {
+    const t = new StubTransport();
+    const p = createProcessor({ transport: t, maxBatch: 3, flushIntervalMs: 9999 });
+    p.emit(makeRecord(1));
+    p.emit(makeRecord(2));
+    expect(t.calls.length).toBe(0);
+    p.emit(makeRecord(3));
+    await vi.waitFor(() => expect(t.calls.length).toBe(1));
+    expect(t.calls[0]).toHaveLength(3);
+  });
+
+  it('flushes when flushIntervalMs elapses', async () => {
+    const t = new StubTransport();
+    const p = createProcessor({ transport: t, maxBatch: 999, flushIntervalMs: 500 });
+    p.emit(makeRecord(1));
+    p.emit(makeRecord(2));
+    expect(t.calls.length).toBe(0);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(t.calls.length).toBe(1);
+    expect(t.calls[0]).toHaveLength(2);
+  });
+
+  it('pushes records to ring on transport failure and drains them on next flush', async () => {
+    const t = new StubTransport();
+    t.result = { ok: false, reason: 'boom' };
+    const p = createProcessor({ transport: t, maxBatch: 2, flushIntervalMs: 9999 });
+    p.emit(makeRecord(1));
+    p.emit(makeRecord(2));
+    await vi.waitFor(() => expect(t.calls.length).toBe(1));
+    // first attempt failed; records buffered in ring
+    t.result = { ok: true };
+    p.emit(makeRecord(3));
+    p.emit(makeRecord(4));
+    await vi.waitFor(() => expect(t.calls.length).toBe(2));
+    // second flush sends ring contents first, then new batch
+    expect(t.calls[1].map((r) => r.timestamp)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('shutdown flushes pending and calls transport.shutdown', async () => {
+    const t = new StubTransport();
+    const p = createProcessor({ transport: t, maxBatch: 999, flushIntervalMs: 9999 });
+    p.emit(makeRecord(1));
+    await p.shutdown();
+    expect(t.calls.length).toBe(1);
+    expect(t.calls[0]).toHaveLength(1);
+    expect(t.shutdownCalled).toBe(true);
+  });
+
+  it('does not flush when emit() is called and pending is empty after a prior flush', async () => {
+    const t = new StubTransport();
+    const p = createProcessor({ transport: t, maxBatch: 1, flushIntervalMs: 9999 });
+    p.emit(makeRecord(1));
+    await vi.waitFor(() => expect(t.calls.length).toBe(1));
+    // no further emit, no further flush
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(t.calls.length).toBe(1);
+  });
+
+  it('respects ringMaxBytes by evicting oldest buffered failures', async () => {
+    const t = new StubTransport();
+    t.result = { ok: false, reason: 'boom' };
+    // ringMaxBytes is bytes of JSON-serialised records; pick a small value to force eviction.
+    // One record's JSON is well under 200 bytes for this test shape, so set 250 bytes -> ~1 record fits.
+    const p = createProcessor({
+      transport: t,
+      maxBatch: 1,
+      flushIntervalMs: 9999,
+      ringMaxBytes: 250,
+    });
+    p.emit(makeRecord(1));
+    await vi.waitFor(() => expect(t.calls.length).toBe(1));
+    p.emit(makeRecord(2));
+    await vi.waitFor(() => expect(t.calls.length).toBe(2));
+    p.emit(makeRecord(3));
+    await vi.waitFor(() => expect(t.calls.length).toBe(3));
+    // ring should have evicted older records, retaining most recent.
+    t.result = { ok: true };
+    p.emit(makeRecord(4));
+    await vi.waitFor(() => expect(t.calls.length).toBe(4));
+    const final = t.calls[3].map((r) => r.timestamp);
+    // Latest attempt sends whatever survived in ring + the new record.
+    expect(final[final.length - 1]).toBe(4);
+    expect(final.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/core/src/__tests__/logging/ring-buffer.test.ts
+++ b/packages/core/src/__tests__/logging/ring-buffer.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { RingBuffer } from '../../logging/ring-buffer';
+
+describe('RingBuffer', () => {
+  it('stores items up to max size', () => {
+    const b = new RingBuffer<number>({ maxBytes: 1024, sizeOf: () => 8 });
+    b.push(1);
+    b.push(2);
+    expect(b.drain()).toEqual([1, 2]);
+  });
+
+  it('evicts oldest when over maxBytes', () => {
+    const b = new RingBuffer<number>({ maxBytes: 24, sizeOf: () => 8 });
+    b.push(1);
+    b.push(2);
+    b.push(3);
+    b.push(4); // 32 bytes -> trim to 24
+    expect(b.drain()).toEqual([2, 3, 4]);
+  });
+
+  it('drain empties the buffer', () => {
+    const b = new RingBuffer<number>({ maxBytes: 1024, sizeOf: () => 8 });
+    b.push(1);
+    b.drain();
+    expect(b.drain()).toEqual([]);
+  });
+
+  it('reports current size', () => {
+    const b = new RingBuffer<number>({ maxBytes: 1024, sizeOf: () => 8 });
+    expect(b.size).toBe(0);
+    b.push(1);
+    b.push(2);
+    expect(b.size).toBe(2);
+  });
+});

--- a/packages/core/src/adapters.ts
+++ b/packages/core/src/adapters.ts
@@ -7,6 +7,7 @@
  */
 
 import type {} from './types/index';
+import { NoopTransport, type LogTransport, type ResourceAttrs } from './logging';
 
 // ---------------------------------------------------------------------------
 // StorageAdapter — replaces chrome.storage.sync/local
@@ -147,7 +148,21 @@ export interface BridgeHealth {
 }
 
 // ---------------------------------------------------------------------------
-// PlatformAdapters — combined context for dependency injection
+// LoggingAdapter, platform-specific transport/resource lifecycle wrapper
+// ---------------------------------------------------------------------------
+
+export interface LoggingAdapter {
+  /**
+   * Build the transport for this platform (file, IPC, native-host, etc.)
+   * and return the resource attributes that describe this process.
+   */
+  build(): { transport: LogTransport; resource: ResourceAttrs };
+  /** Optional teardown hook (close file descriptors, etc.). */
+  dispose?(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// PlatformAdapters, combined context for dependency injection
 // ---------------------------------------------------------------------------
 
 export interface PlatformAdapters {
@@ -158,6 +173,7 @@ export interface PlatformAdapters {
   export: ExportAdapter;
   git?: GitAdapter;
   bridgeHealth?: BridgeHealth;
+  logging?: LoggingAdapter;
 }
 
 // ---------------------------------------------------------------------------
@@ -298,6 +314,23 @@ export class NoopBridgeHealth implements BridgeHealth {
   onStateChange(_cb: (state: BridgeHealth['state']) => void): void {
     // No-op — state never changes
   }
+}
+
+/** Logging adapter that uses the noop transport and a placeholder resource */
+export class NoopLoggingAdapter implements LoggingAdapter {
+  build(): { transport: LogTransport; resource: ResourceAttrs } {
+    return {
+      transport: NoopTransport,
+      resource: {
+        'service.name': 'mdview',
+        'service.version': '0.0.0',
+        'service.namespace': 'electron-main',
+        'deployment.environment': 'dev',
+        'host.os': 'unknown',
+      },
+    };
+  }
+  async dispose(): Promise<void> {}
 }
 
 /** Create a PlatformAdapters bundle with all no-op defaults */

--- a/packages/core/src/logging/file-rotation.ts
+++ b/packages/core/src/logging/file-rotation.ts
@@ -1,0 +1,108 @@
+export type LogSource = 'electron' | 'chrome' | 'native-host';
+
+export interface DirEntry {
+  name: string;
+  size: number;
+}
+
+export interface RotationOpts {
+  source: LogSource;
+  today: Date;
+  maxBytes: number;
+  retentionDays: number;
+}
+
+export type RotationAction =
+  | { kind: 'append'; file: string }
+  | { kind: 'rollover-date'; from: string; to: string }
+  | { kind: 'rollover-size'; from: string; renameTo: string; to: string };
+
+const MS_PER_DAY = 86_400_000;
+
+// Returns the YYYY-MM-DD date stem in UTC, keeping tests timezone-independent.
+export function dateStem(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+export function currentFileName(source: LogSource, today: Date): string {
+  return `mdview-${source}-${dateStem(today)}.jsonl`;
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function sourceFilenameRegex(source: LogSource): RegExp {
+  return new RegExp(`^mdview-${escapeRegExp(source)}-(\\d{4}-\\d{2}-\\d{2})\\.jsonl(?:\\.\\d+)?$`);
+}
+
+export function nextSizeSuffix(dir: readonly DirEntry[], baseName: string): number {
+  const prefix = `${baseName}.`;
+  const used = new Set<number>();
+  for (const entry of dir) {
+    if (!entry.name.startsWith(prefix)) continue;
+    const tail = entry.name.slice(prefix.length);
+    if (!/^\d+$/.test(tail)) continue;
+    const n = Number.parseInt(tail, 10);
+    if (n > 0) used.add(n);
+  }
+  let n = 1;
+  while (used.has(n)) n += 1;
+  return n;
+}
+
+export function planRotation(
+  dir: readonly DirEntry[],
+  currentFile: string | null,
+  currentBytes: number,
+  pendingBytes: number,
+  opts: RotationOpts
+): RotationAction {
+  const target = currentFileName(opts.source, opts.today);
+
+  if (currentFile === null) {
+    return { kind: 'append', file: target };
+  }
+
+  if (currentFile !== target) {
+    return { kind: 'rollover-date', from: currentFile, to: target };
+  }
+
+  if (currentBytes + pendingBytes > opts.maxBytes) {
+    const suffix = nextSizeSuffix(dir, currentFile);
+    return {
+      kind: 'rollover-size',
+      from: currentFile,
+      renameTo: `${currentFile}.${suffix}`,
+      to: currentFile,
+    };
+  }
+
+  return { kind: 'append', file: currentFile };
+}
+
+export function planPrune(
+  dir: readonly DirEntry[],
+  opts: { today: Date; retentionDays: number; source: LogSource }
+): string[] {
+  const re = sourceFilenameRegex(opts.source);
+  const todayMs = Date.UTC(
+    opts.today.getUTCFullYear(),
+    opts.today.getUTCMonth(),
+    opts.today.getUTCDate()
+  );
+  const cutoffMs = todayMs - opts.retentionDays * MS_PER_DAY;
+
+  const out: string[] = [];
+  for (const entry of dir) {
+    const match = re.exec(entry.name);
+    if (!match) continue;
+    const stem = match[1];
+    const [y, m, day] = stem.split('-').map((s) => Number.parseInt(s, 10));
+    const entryMs = Date.UTC(y, m - 1, day);
+    if (entryMs < cutoffMs) {
+      out.push(entry.name);
+    }
+  }
+  return out;
+}

--- a/packages/core/src/logging/index.ts
+++ b/packages/core/src/logging/index.ts
@@ -1,0 +1,129 @@
+import type { Attributes, LogRecord, ResourceAttrs } from './log-record';
+import { createLogger, type Logger } from './logger';
+import { BatchLogRecordProcessor, createProcessor } from './processor';
+import { RingBuffer } from './ring-buffer';
+import type { LogTransport } from './transport';
+
+export interface InitLoggingOpts {
+  transport: LogTransport;
+  resource: ResourceAttrs;
+  maxBatch?: number;
+  flushIntervalMs?: number;
+  ringMaxBytes?: number;
+}
+
+// Placeholder resource used by loggers obtained before initLogging runs.
+// Pre-init records keep this placeholder permanently; we do not retroactively
+// rewrite history because the boot-time uncertainty is meaningful signal.
+const PLACEHOLDER_RESOURCE: ResourceAttrs = {
+  'service.name': 'mdview',
+  'service.version': '0.0.0',
+  'service.namespace': 'electron-main',
+  'deployment.environment': 'dev',
+  'host.os': 'unknown',
+};
+
+const PRE_INIT_BUFFER_MAX_BYTES = 1_048_576;
+
+type State =
+  | { kind: 'pending'; buffer: RingBuffer<LogRecord> }
+  | { kind: 'ready'; processor: BatchLogRecordProcessor; resource: ResourceAttrs };
+
+function freshPendingState(): State {
+  return {
+    kind: 'pending',
+    buffer: new RingBuffer<LogRecord>({
+      maxBytes: PRE_INIT_BUFFER_MAX_BYTES,
+      sizeOf: (r) => JSON.stringify(r).length,
+    }),
+  };
+}
+
+let state: State = freshPendingState();
+const loggerCache = new Map<string, Logger>();
+
+// routedEmit is the shared sink for every cached logger. It reads the current
+// state at call time, rewrites `record.resource` to the live resource when the
+// processor is ready, and otherwise buffers into the pre-init RingBuffer with
+// the placeholder resource intact. This is what gives logger identity stability
+// across initLogging: the closure captured in createLogger keeps pointing at
+// the same function, but the routing target changes.
+function routedEmit(record: LogRecord): void {
+  if (state.kind === 'pending') {
+    state.buffer.push(record);
+    return;
+  }
+  // Post-init: stamp the live resource on the record so loggers obtained
+  // before init still emit records with the real resource for any post-init
+  // calls. Pre-init records replayed during initLogging keep their placeholder.
+  const stamped: LogRecord = { ...record, resource: state.resource };
+  state.processor.emit(stamped);
+}
+
+export function initLogging(opts: InitLoggingOpts): void {
+  if (state.kind === 'ready') {
+    // Re-init without shutdown: best-effort replacement.
+    // eslint-disable-next-line no-console
+    console.warn('initLogging called twice without shutdownLogging in between');
+  }
+  const processor = createProcessor({
+    transport: opts.transport,
+    maxBatch: opts.maxBatch,
+    flushIntervalMs: opts.flushIntervalMs,
+    ringMaxBytes: opts.ringMaxBytes,
+  });
+
+  const previous = state;
+  state = { kind: 'ready', processor, resource: opts.resource };
+
+  if (previous.kind === 'pending') {
+    const drained = previous.buffer.drain();
+    // Replay records keep their original placeholder resource by design.
+    // We emit one at a time; with small maxBatch values the processor's
+    // in-flight flush can deflect subsequent flushes, so we schedule a
+    // follow-up flush on the next microtask to drain anything left in
+    // pending once the initial export settles.
+    for (const r of drained) processor.emit(r);
+    if (drained.length > 0) {
+      queueMicrotask(() => {
+        void processor.flush();
+      });
+    }
+  }
+}
+
+export async function shutdownLogging(): Promise<void> {
+  if (state.kind === 'ready') {
+    const processor = state.processor;
+    state = freshPendingState();
+    loggerCache.clear();
+    await processor.shutdown();
+    return;
+  }
+  // Pending: just reset.
+  state = freshPendingState();
+  loggerCache.clear();
+}
+
+export function getLogger(name: string, attrs?: Attributes): Logger {
+  const cached = loggerCache.get(name);
+  if (cached) return cached;
+  // Resource passed here is the placeholder; routedEmit rewrites it to the
+  // live resource after initLogging. Pre-init buffered records keep the
+  // placeholder, by design.
+  const logger = createLogger({
+    emit: routedEmit,
+    resource: PLACEHOLDER_RESOURCE,
+    namespace: name,
+    baseAttrs: attrs,
+  });
+  loggerCache.set(name, logger);
+  return logger;
+}
+
+// Re-exports
+export type { LogRecord, Attributes, LogLevel, ResourceAttrs } from './log-record';
+export type { Logger, Span } from './logger';
+export type { LogTransport, TransportResult } from './transport';
+export { NoopTransport } from './transport';
+export * from './semconv';

--- a/packages/core/src/logging/log-record.ts
+++ b/packages/core/src/logging/log-record.ts
@@ -1,0 +1,51 @@
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+export type SeverityText = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'FATAL';
+
+export type Attributes = Readonly<Record<string, string | number | boolean | undefined>>;
+
+export interface ResourceAttrs {
+  'service.name': 'mdview';
+  'service.version': string;
+  'service.namespace':
+    | 'chrome-ext'
+    | 'chrome-content'
+    | 'chrome-sw'
+    | 'electron-main'
+    | 'electron-renderer'
+    | 'native-host';
+  'deployment.environment': 'dev' | 'prod';
+  'host.os': string;
+}
+
+export interface LogRecord {
+  timestamp: number;
+  observedTimestamp: number;
+  severityNumber: number;
+  severityText: SeverityText;
+  body: string;
+  attributes: Attributes;
+  resource: ResourceAttrs;
+  traceId?: string;
+  spanId?: string;
+}
+
+const NUM_BY_LEVEL: Record<LogLevel, number> = {
+  trace: 1,
+  debug: 5,
+  info: 9,
+  warn: 13,
+  error: 17,
+  fatal: 21,
+};
+
+const TEXT_BY_NUM: Record<number, SeverityText> = {
+  1: 'TRACE',
+  5: 'DEBUG',
+  9: 'INFO',
+  13: 'WARN',
+  17: 'ERROR',
+  21: 'FATAL',
+};
+
+export const severityNumberFor = (lvl: LogLevel): number => NUM_BY_LEVEL[lvl];
+export const severityTextFor = (n: number): SeverityText => TEXT_BY_NUM[n] ?? 'INFO';

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -1,0 +1,291 @@
+import type { Attributes, LogRecord, LogLevel, ResourceAttrs, SeverityText } from './log-record';
+import { severityNumberFor, severityTextFor } from './log-record';
+import {
+  ATTR_CODE_NAMESPACE,
+  ATTR_DURATION_NS,
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
+} from './semconv';
+
+export interface Span {
+  setAttribute(key: string, value: string | number | boolean): void;
+  addEvent(name: string, attrs?: Attributes): void;
+}
+
+export interface Logger {
+  trace(msg: string, attrs?: Attributes): void;
+  debug(msg: string, attrs?: Attributes): void;
+  info(msg: string, attrs?: Attributes): void;
+  warn(msg: string, attrs?: Attributes): void;
+  error(msg: string, attrs?: Attributes, err?: Error): void;
+  fatal(msg: string, attrs?: Attributes, err?: Error): void;
+  child(name: string, attrs?: Attributes): Logger;
+  withSpan<T>(name: string, fn: (span: Span) => T, attrs?: Attributes): T;
+}
+
+export interface EmitFn {
+  (record: LogRecord): void;
+}
+
+export interface CreateLoggerOpts {
+  emit: EmitFn;
+  resource: ResourceAttrs;
+  namespace?: string;
+  baseAttrs?: Attributes;
+  now?: () => number;
+  randomBytes?: (n: number) => Uint8Array;
+}
+
+const ATTR_SPAN_NAME = 'mdview.span.name';
+const ATTR_SPAN_STATUS = 'mdview.span.status';
+const ATTR_SPAN_EVENT = 'mdview.span.event';
+
+type MutableAttrs = Record<string, string | number | boolean | undefined>;
+
+interface NodeCryptoLike {
+  randomBytes(n: number): Uint8Array;
+}
+
+function resolveDefaultRandomBytes(): (n: number) => Uint8Array {
+  // Try Node first, then Web Crypto.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const req = (globalThis as { require?: (m: string) => unknown }).require;
+    if (typeof req === 'function') {
+      const mod = req('crypto') as NodeCryptoLike | undefined;
+      if (mod && typeof mod.randomBytes === 'function') {
+        return (n: number) => new Uint8Array(mod.randomBytes(n));
+      }
+    }
+  } catch {
+    // fall through to web crypto
+  }
+  const webCrypto = (globalThis as { crypto?: Crypto }).crypto;
+  if (webCrypto && typeof webCrypto.getRandomValues === 'function') {
+    return (n: number) => {
+      const out = new Uint8Array(n);
+      webCrypto.getRandomValues(out);
+      return out;
+    };
+  }
+  // Last-resort, non-crypto fallback. Should never be reached in supported envs.
+  return (n: number) => {
+    const out = new Uint8Array(n);
+    for (let i = 0; i < n; i++) out[i] = Math.floor(Math.random() * 256);
+    return out;
+  };
+}
+
+const defaultRandomBytes = resolveDefaultRandomBytes();
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function isThenable(v: unknown): v is PromiseLike<unknown> {
+  return v != null && typeof (v as { then?: unknown }).then === 'function';
+}
+
+function liftException(err: unknown): MutableAttrs {
+  if (err instanceof Error) {
+    return {
+      [ATTR_EXCEPTION_TYPE]: err.name,
+      [ATTR_EXCEPTION_MESSAGE]: err.message,
+      [ATTR_EXCEPTION_STACKTRACE]: err.stack ?? '',
+    };
+  }
+  // Try to lift Error-shaped values.
+  if (err && typeof err === 'object') {
+    const e = err as { name?: unknown; message?: unknown; stack?: unknown };
+    return {
+      [ATTR_EXCEPTION_TYPE]: typeof e.name === 'string' ? e.name : 'Error',
+      [ATTR_EXCEPTION_MESSAGE]: typeof e.message === 'string' ? e.message : String(err),
+      [ATTR_EXCEPTION_STACKTRACE]: typeof e.stack === 'string' ? e.stack : '',
+    };
+  }
+  return {
+    [ATTR_EXCEPTION_TYPE]: 'Error',
+    [ATTR_EXCEPTION_MESSAGE]: String(err),
+    [ATTR_EXCEPTION_STACKTRACE]: '',
+  };
+}
+
+function mergeAttrs(...parts: (Attributes | MutableAttrs | undefined)[]): Attributes {
+  const out: MutableAttrs = {};
+  for (const p of parts) {
+    if (!p) continue;
+    for (const k of Object.keys(p)) {
+      const v = (p as MutableAttrs)[k];
+      if (v !== undefined) out[k] = v;
+    }
+  }
+  return out as Attributes;
+}
+
+interface InternalLoggerState {
+  emit: EmitFn;
+  resource: ResourceAttrs;
+  namespace: string | undefined;
+  baseAttrs: Attributes;
+  now: () => number;
+  randomBytes: (n: number) => Uint8Array;
+}
+
+function buildRecord(
+  state: InternalLoggerState,
+  level: LogLevel,
+  body: string,
+  callAttrs: Attributes | undefined,
+  extra: MutableAttrs | undefined,
+  ids: { traceId?: string; spanId?: string } | undefined
+): LogRecord {
+  const ns: MutableAttrs | undefined = state.namespace
+    ? { [ATTR_CODE_NAMESPACE]: state.namespace }
+    : undefined;
+  // Priority (lowest -> highest): namespace, baseAttrs, extra (lifted), callAttrs.
+  const attributes = mergeAttrs(ns, state.baseAttrs, extra, callAttrs);
+  const ms = state.now();
+  const ts = ms * 1_000_000;
+  const severityNumber = severityNumberFor(level);
+  const severityText: SeverityText = severityTextFor(severityNumber);
+  const record: LogRecord = {
+    timestamp: ts,
+    observedTimestamp: ts,
+    severityNumber,
+    severityText,
+    body,
+    attributes,
+    resource: state.resource,
+  };
+  if (ids?.traceId) record.traceId = ids.traceId;
+  if (ids?.spanId) record.spanId = ids.spanId;
+  return record;
+}
+
+function makeLogger(state: InternalLoggerState): Logger {
+  const emitLevel = (level: LogLevel, body: string, attrs?: Attributes, err?: Error): void => {
+    const extra = err ? liftException(err) : undefined;
+    state.emit(buildRecord(state, level, body, attrs, extra, undefined));
+  };
+
+  const child = (name: string, attrs?: Attributes): Logger => {
+    const childNs = state.namespace ? `${state.namespace}.${name}` : name;
+    const merged = mergeAttrs(state.baseAttrs, attrs);
+    return makeLogger({
+      emit: state.emit,
+      resource: state.resource,
+      namespace: childNs,
+      baseAttrs: merged,
+      now: state.now,
+      randomBytes: state.randomBytes,
+    });
+  };
+
+  function withSpan<T>(name: string, fn: (span: Span) => T, attrs?: Attributes): T {
+    const traceId = bytesToHex(state.randomBytes(16));
+    const spanId = bytesToHex(state.randomBytes(8));
+    const ids = { traceId, spanId };
+    const spanAttrs: MutableAttrs = { [ATTR_SPAN_NAME]: name };
+
+    const span: Span = {
+      setAttribute(key: string, value: string | number | boolean) {
+        spanAttrs[key] = value;
+      },
+      addEvent(eventName: string, eventAttrs?: Attributes) {
+        const merged: MutableAttrs = { ...spanAttrs, [ATTR_SPAN_EVENT]: eventName };
+        if (eventAttrs) {
+          for (const k of Object.keys(eventAttrs)) {
+            const v = eventAttrs[k];
+            if (v !== undefined) merged[k] = v;
+          }
+        }
+        state.emit(buildRecord(state, 'info', eventName, merged as Attributes, undefined, ids));
+      },
+    };
+
+    const start = state.now();
+    state.emit(
+      buildRecord(state, 'info', `${name}.start`, mergeAttrs(spanAttrs, attrs), undefined, ids)
+    );
+
+    const emitException = (err: unknown): void => {
+      const lifted = liftException(err);
+      const exAttrs = mergeAttrs(spanAttrs, lifted);
+      state.emit(buildRecord(state, 'error', 'exception', exAttrs, undefined, ids));
+    };
+
+    const emitEnd = (status: 'ok' | 'error'): void => {
+      const end = state.now();
+      const duration = (end - start) * 1_000_000;
+      const endAttrs: MutableAttrs = {
+        ...spanAttrs,
+        [ATTR_SPAN_STATUS]: status,
+        [ATTR_DURATION_NS]: duration,
+      };
+      state.emit(buildRecord(state, 'info', `${name}.end`, endAttrs as Attributes, undefined, ids));
+    };
+
+    let result: T;
+    try {
+      result = fn(span);
+    } catch (err) {
+      emitException(err);
+      emitEnd('error');
+      throw err;
+    }
+
+    if (isThenable(result)) {
+      const p = (result as unknown as Promise<unknown>).then(
+        (value) => {
+          emitEnd('ok');
+          return value;
+        },
+        (err) => {
+          emitException(err);
+          emitEnd('error');
+          throw err;
+        }
+      );
+      return p as unknown as T;
+    }
+
+    emitEnd('ok');
+    return result;
+  }
+
+  return {
+    trace(msg, attrs) {
+      emitLevel('trace', msg, attrs);
+    },
+    debug(msg, attrs) {
+      emitLevel('debug', msg, attrs);
+    },
+    info(msg, attrs) {
+      emitLevel('info', msg, attrs);
+    },
+    warn(msg, attrs) {
+      emitLevel('warn', msg, attrs);
+    },
+    error(msg, attrs, err) {
+      emitLevel('error', msg, attrs, err);
+    },
+    fatal(msg, attrs, err) {
+      emitLevel('fatal', msg, attrs, err);
+    },
+    child,
+    withSpan,
+  };
+}
+
+export function createLogger(opts: CreateLoggerOpts): Logger {
+  const state: InternalLoggerState = {
+    emit: opts.emit,
+    resource: opts.resource,
+    namespace: opts.namespace,
+    baseAttrs: opts.baseAttrs ?? {},
+    now: opts.now ?? Date.now,
+    randomBytes: opts.randomBytes ?? defaultRandomBytes,
+  };
+  return makeLogger(state);
+}

--- a/packages/core/src/logging/processor.ts
+++ b/packages/core/src/logging/processor.ts
@@ -1,0 +1,78 @@
+import { RingBuffer } from './ring-buffer';
+import type { LogRecord } from './log-record';
+import type { LogTransport } from './transport';
+
+export interface ProcessorOpts {
+  transport: LogTransport;
+  maxBatch?: number;
+  flushIntervalMs?: number;
+  ringMaxBytes?: number;
+}
+
+interface ResolvedOpts {
+  transport: LogTransport;
+  maxBatch: number;
+  flushIntervalMs: number;
+  ringMaxBytes: number;
+}
+
+export class BatchLogRecordProcessor {
+  private pending: LogRecord[] = [];
+  private ring: RingBuffer<LogRecord>;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private flushing = false;
+
+  constructor(private opts: ResolvedOpts) {
+    this.ring = new RingBuffer<LogRecord>({
+      maxBytes: opts.ringMaxBytes,
+      sizeOf: (r) => JSON.stringify(r).length,
+    });
+  }
+
+  emit(record: LogRecord): void {
+    this.pending.push(record);
+    if (this.pending.length >= this.opts.maxBatch) {
+      void this.flush();
+    } else if (this.timer === null) {
+      this.timer = setTimeout(() => void this.flush(), this.opts.flushIntervalMs);
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.flushing) return;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    const drained = this.ring.drain();
+    const batch = [...drained, ...this.pending];
+    this.pending = [];
+    if (batch.length === 0) return;
+
+    this.flushing = true;
+    try {
+      const result = await this.opts.transport.export(batch);
+      if (!result.ok) {
+        for (const r of batch) this.ring.push(r);
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    await this.flush();
+    if (this.opts.transport.shutdown) {
+      await this.opts.transport.shutdown();
+    }
+  }
+}
+
+export function createProcessor(opts: ProcessorOpts): BatchLogRecordProcessor {
+  return new BatchLogRecordProcessor({
+    transport: opts.transport,
+    maxBatch: opts.maxBatch ?? 64,
+    flushIntervalMs: opts.flushIntervalMs ?? 2000,
+    ringMaxBytes: opts.ringMaxBytes ?? 1_048_576,
+  });
+}

--- a/packages/core/src/logging/ring-buffer.ts
+++ b/packages/core/src/logging/ring-buffer.ts
@@ -1,0 +1,31 @@
+export interface RingBufferOpts<T> {
+  maxBytes: number;
+  sizeOf: (item: T) => number;
+}
+
+export class RingBuffer<T> {
+  private items: T[] = [];
+  private bytes = 0;
+
+  constructor(private opts: RingBufferOpts<T>) {}
+
+  push(item: T): void {
+    this.items.push(item);
+    this.bytes += this.opts.sizeOf(item);
+    while (this.bytes > this.opts.maxBytes && this.items.length > 0) {
+      const dropped = this.items.shift() as T;
+      this.bytes -= this.opts.sizeOf(dropped);
+    }
+  }
+
+  drain(): T[] {
+    const out = this.items;
+    this.items = [];
+    this.bytes = 0;
+    return out;
+  }
+
+  get size(): number {
+    return this.items.length;
+  }
+}

--- a/packages/core/src/logging/semconv.ts
+++ b/packages/core/src/logging/semconv.ts
@@ -1,0 +1,16 @@
+// semconv.ts
+// Centralised attribute keys. No magic strings at call sites.
+export const ATTR_CODE_NAMESPACE = 'code.namespace';
+export const ATTR_CODE_FUNCTION = 'code.function';
+export const ATTR_EXCEPTION_TYPE = 'exception.type';
+export const ATTR_EXCEPTION_MESSAGE = 'exception.message';
+export const ATTR_EXCEPTION_STACKTRACE = 'exception.stacktrace';
+export const ATTR_DURATION_NS = 'duration_ns';
+
+// mdview-specific
+export const ATTR_MDVIEW_COMMENT_ID = 'mdview.comment.id';
+export const ATTR_MDVIEW_COMMENT_OP = 'mdview.comment.op';
+export const ATTR_MDVIEW_FILE_PATH = 'mdview.file.path';
+export const ATTR_MDVIEW_IPC_CHANNEL = 'mdview.ipc.channel';
+export const ATTR_MDVIEW_BRIDGE_ATTEMPT = 'mdview.bridge.attempt';
+export const ATTR_MDVIEW_BRIDGE_OUTCOME = 'mdview.bridge.outcome';

--- a/packages/core/src/logging/transport.ts
+++ b/packages/core/src/logging/transport.ts
@@ -1,0 +1,17 @@
+import type { LogRecord } from './log-record';
+
+export interface TransportResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export interface LogTransport {
+  export(records: readonly LogRecord[]): Promise<TransportResult>;
+  shutdown?(): Promise<void>;
+}
+
+export const NoopTransport: LogTransport = {
+  export() {
+    return Promise.resolve({ ok: true });
+  },
+};

--- a/packages/core/src/utils/debug-logger.ts
+++ b/packages/core/src/utils/debug-logger.ts
@@ -9,6 +9,37 @@
 
 import type { LogLevel } from '../types/index';
 import type { StorageAdapter } from '../adapters';
+import { getLogger } from '../logging';
+import type { Logger } from '../logging';
+
+const LEGACY_LOGGER_NAME = 'legacy.debug';
+const ATTR_CONTEXT = 'mdview.debug.context';
+const ATTR_TABLE = 'mdview.debug.table';
+const ATTR_TIMER = 'mdview.debug.timer';
+const ATTR_GROUP_LABEL = 'mdview.debug.group.label';
+
+function legacy(): Logger {
+  return getLogger(LEGACY_LOGGER_NAME);
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function joinArgs(args: unknown[]): string {
+  if (args.length === 0) return '';
+  return args
+    .map((a) => {
+      if (typeof a === 'string') return a;
+      if (a instanceof Error) return a.message;
+      return safeStringify(a);
+    })
+    .join(' ');
+}
 
 const LEVEL_PRIORITY: Record<LogLevel, number> = {
   none: 0,
@@ -66,6 +97,7 @@ export class DebugLogger {
     if (this.shouldLog('debug')) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
       console.log(`[${context}]`, ...(args as any[]));
+      legacy().debug(joinArgs(args), { [ATTR_CONTEXT]: context });
     }
   }
 
@@ -73,6 +105,7 @@ export class DebugLogger {
     if (this.shouldLog('debug')) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
       console.debug(`[${context}]`, ...(args as any[]));
+      legacy().debug(joinArgs(args), { [ATTR_CONTEXT]: context });
     }
   }
 
@@ -80,6 +113,7 @@ export class DebugLogger {
     if (this.shouldLog('info')) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
       console.info(`[${context}]`, ...(args as any[]));
+      legacy().info(joinArgs(args), { [ATTR_CONTEXT]: context });
     }
   }
 
@@ -87,6 +121,7 @@ export class DebugLogger {
     if (this.shouldLog('warn')) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
       console.warn(`[${context}]`, ...(args as any[]));
+      legacy().warn(joinArgs(args), { [ATTR_CONTEXT]: context });
     }
   }
 
@@ -94,12 +129,14 @@ export class DebugLogger {
     if (this.shouldLog('error')) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
       console.error(`[${context}]`, ...(args as any[]));
+      legacy().error(joinArgs(args), { [ATTR_CONTEXT]: context });
     }
   }
 
   group(context: string, label: string): void {
     if (this.shouldLog('debug')) {
       console.group(`[${context}] ${label}`);
+      legacy().debug(label, { [ATTR_CONTEXT]: context, [ATTR_GROUP_LABEL]: label });
     }
   }
 
@@ -114,18 +151,24 @@ export class DebugLogger {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       console.log(`[${context}]`);
       console.table(data);
+      legacy().info(context, {
+        [ATTR_CONTEXT]: context,
+        [ATTR_TABLE]: safeStringify(data).slice(0, 4096),
+      });
     }
   }
 
   time(context: string, label: string): void {
     if (this.shouldLog('debug')) {
       console.time(`[${context}] ${label}`);
+      legacy().info(`${label}.start`, { [ATTR_CONTEXT]: context, [ATTR_TIMER]: label });
     }
   }
 
   timeEnd(context: string, label: string): void {
     if (this.shouldLog('debug')) {
       console.timeEnd(`[${context}] ${label}`);
+      legacy().info(`${label}.end`, { [ATTR_CONTEXT]: context, [ATTR_TIMER]: label });
     }
   }
 }


### PR DESCRIPTION
## Summary

Lands Phase 1 of the shared logging design: the core infrastructure for an OpenTelemetry-shaped logger usable from the Electron app, Chrome extension, and native host. **No production call sites are migrated in this PR.** `DebugLogger` is shimmed to route through the new pipeline so existing logs flow once a transport is wired up in a follow-up.

The motivation is operational: Chrome extension comments fail intermittently and there is no persisted record of what happened in a user's session. The next phases (separate PRs) will wire platform transports (rotated JSONL in `os.tmpdir()/mdview/logs/`), then instrument the comment lifecycle, IPC handlers, native-host bridge, and other high-value boundaries.

### What's in this PR

- ` packages/core/src/logging/` (new module)
  - `log-record.ts` - OTEL `LogRecord` types and severity mapping
  - `semconv.ts` - centralised attribute keys
  - `ring-buffer.ts` - bounded byte-counting buffer for retry on transport failure
  - `transport.ts` - `LogTransport` interface and `NoopTransport`
  - `processor.ts` - `BatchLogRecordProcessor` (64 records / 2s, ring on failure)
  - `file-rotation.ts` - pure rotation/retention planner (no fs, shared between Electron and the native host)
  - `logger.ts` - `Logger` with child loggers and in-process spans (start/end records share `traceId`/`spanId` with `duration_ns`)
  - `index.ts` - public surface with pre-init buffering so calls before `initLogging` are not lost
- `packages/core/src/adapters.ts`
  - New `LoggingAdapter` interface and `NoopLoggingAdapter`, added as an optional field on `PlatformAdapters`
- `packages/core/src/utils/debug-logger.ts`
  - Now routes through `getLogger('legacy.debug')` while preserving its public API (existing call sites unchanged)

### Design and follow-up plan

- Design doc: `~/.claude/plans/mdview/2026-05-11-otel-logging-design.md` (local plan, not in-repo)
- Phase 1 plan: `~/.claude/plans/mdview/2026-05-11-otel-logging-phase1-plan.md`
- Subsequent phases (not in this PR): Electron `FileTransport` and IPC bridge, Chrome `NativeHostTransport` + IndexedDB fallback, native-host `LOG_BATCH` handler, then per-feature wire-ups starting with the comment lifecycle.

### Known follow-up

`BatchLogRecordProcessor.flush` early-returns if a flush is already in-flight. `index.ts` works around this with a `queueMicrotask` after replaying the pre-init buffer. The cleaner fix is to make the processor re-check `pending` at the end of a flush and recurse if non-empty. Filed as a small follow-up; behaviour is correct today.

## Test plan

- [x] `bunx vitest run packages/core` - 380 tests pass, including the 41 new logging tests
- [x] `bun run --filter '@mdreview/core' build` - DTS and ESM build clean
- [ ] Phase 2 wiring (Electron + Chrome + native-host transports) will run in a follow-up PR; verified locally via the in-memory smoke test of the ring + processor + logger pipeline
- [ ] User to spot-check the new module before Phase 2 lands