### PR TITLE
feat(logging): platform transports and native-host wire-up (Phase 2)

### DIFF
--- a/packages/chrome-ext/src/__tests__/logging/bridge-recovery.test.ts
+++ b/packages/chrome-ext/src/__tests__/logging/bridge-recovery.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBridgeRecovery } from '../../background/logging/bridge-recovery';
+
+type BridgeState = 'connected' | 'reconnecting' | 'disconnected';
+
+class FakeBridge {
+  cb?: (s: BridgeState) => void;
+  onStateChange(cb: (s: BridgeState) => void) {
+    this.cb = cb;
+  }
+  fire(s: BridgeState) {
+    this.cb!(s);
+  }
+}
+
+class FakeTransport {
+  calls = 0;
+  flushFromIdb = vi.fn(() => {
+    this.calls++;
+    return Promise.resolve({ flushed: 0, remaining: 0 });
+  });
+}
+
+describe('BridgeRecovery', () => {
+  it('triggers a flush after debounce on transition to connected', () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const transport = new FakeTransport();
+    const r = createBridgeRecovery({ bridge, transport, debounceMs: 100 });
+    r.start();
+    bridge.fire('connected');
+    expect(transport.calls).toBe(0);
+    vi.advanceTimersByTime(100);
+    expect(transport.calls).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it('debounces repeated connected events into one flush', () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const transport = new FakeTransport();
+    const r = createBridgeRecovery({ bridge, transport, debounceMs: 100 });
+    r.start();
+    bridge.fire('connected');
+    vi.advanceTimersByTime(50);
+    bridge.fire('connected');
+    vi.advanceTimersByTime(50);
+    expect(transport.calls).toBe(0);
+    vi.advanceTimersByTime(50);
+    expect(transport.calls).toBe(1);
+    vi.useRealTimers();
+  });
+
+  it('cancels pending flush when bridge drops before debounce', () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const transport = new FakeTransport();
+    const r = createBridgeRecovery({ bridge, transport, debounceMs: 100 });
+    r.start();
+    bridge.fire('connected');
+    vi.advanceTimersByTime(50);
+    bridge.fire('disconnected');
+    vi.advanceTimersByTime(100);
+    expect(transport.calls).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('cancels pending flush when bridge transitions to reconnecting', () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const transport = new FakeTransport();
+    const r = createBridgeRecovery({ bridge, transport, debounceMs: 100 });
+    r.start();
+    bridge.fire('connected');
+    vi.advanceTimersByTime(50);
+    bridge.fire('reconnecting');
+    vi.advanceTimersByTime(100);
+    expect(transport.calls).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('stop prevents future flushes', () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const transport = new FakeTransport();
+    const r = createBridgeRecovery({ bridge, transport, debounceMs: 100 });
+    r.start();
+    r.stop();
+    bridge.fire('connected');
+    vi.advanceTimersByTime(100);
+    expect(transport.calls).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('stop cancels a pending timer', () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const transport = new FakeTransport();
+    const r = createBridgeRecovery({ bridge, transport, debounceMs: 100 });
+    r.start();
+    bridge.fire('connected');
+    vi.advanceTimersByTime(50);
+    r.stop();
+    vi.advanceTimersByTime(100);
+    expect(transport.calls).toBe(0);
+    vi.useRealTimers();
+  });
+
+  it('swallows transport errors without throwing', async () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const transport = {
+      flushFromIdb: () => Promise.reject(new Error('boom')),
+    } as unknown as { flushFromIdb: () => Promise<{ flushed: number; remaining: number }> };
+    const r = createBridgeRecovery({ bridge, transport, debounceMs: 10 });
+    r.start();
+    bridge.fire('connected');
+    vi.advanceTimersByTime(10);
+    await vi.runAllTimersAsync();
+    // No throw; the callback caught the rejection.
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('uses default debounceMs of 1000 when not specified', () => {
+    vi.useFakeTimers();
+    const bridge = new FakeBridge();
+    const transport = new FakeTransport();
+    const r = createBridgeRecovery({ bridge, transport });
+    r.start();
+    bridge.fire('connected');
+    vi.advanceTimersByTime(999);
+    expect(transport.calls).toBe(0);
+    vi.advanceTimersByTime(1);
+    expect(transport.calls).toBe(1);
+    vi.useRealTimers();
+  });
+});

--- a/packages/chrome-ext/src/__tests__/logging/composite-transport.test.ts
+++ b/packages/chrome-ext/src/__tests__/logging/composite-transport.test.ts
@@ -1,0 +1,130 @@
+import 'fake-indexeddb/auto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import { CompositeTransport } from '../../background/logging/composite-transport';
+import { IndexedDBTransport } from '../../background/logging/indexeddb-transport';
+import type { LogRecord, LogTransport, TransportResult } from '@mdreview/core/logging';
+
+function rec(timestampMs: number, body: string): LogRecord {
+  return {
+    timestamp: timestampMs * 1_000_000,
+    observedTimestamp: timestampMs * 1_000_000,
+    severityNumber: 9,
+    severityText: 'INFO',
+    body,
+    attributes: {},
+    resource: {
+      'service.name': 'mdview',
+      'service.version': '0',
+      'service.namespace': 'chrome-sw',
+      'deployment.environment': 'dev',
+      'host.os': 't',
+    },
+  };
+}
+
+class StubPrimary implements LogTransport {
+  results: TransportResult[] = [];
+  calls: LogRecord[][] = [];
+  resultIndex = 0;
+  shutdownCount = 0;
+
+  export(records: readonly LogRecord[]): Promise<TransportResult> {
+    this.calls.push([...records]);
+    return Promise.resolve(this.results[this.resultIndex++] ?? { ok: true });
+  }
+
+  shutdown(): Promise<void> {
+    this.shutdownCount++;
+    return Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+});
+
+describe('CompositeTransport.export', () => {
+  it('returns ok:true and skips IDB when primary succeeds', async () => {
+    const primary = new StubPrimary();
+    primary.results = [{ ok: true }];
+    const fallback = new IndexedDBTransport();
+    const t = new CompositeTransport({ primary, fallback });
+    expect(await t.export([rec(Date.UTC(2026, 4, 11, 0), 'a')])).toEqual({ ok: true });
+    expect(await fallback.listBuckets()).toEqual([]);
+    await t.shutdown();
+  });
+
+  it('writes to IDB and returns ok:true when primary fails', async () => {
+    const primary = new StubPrimary();
+    primary.results = [{ ok: false, reason: 'down' }];
+    const fallback = new IndexedDBTransport();
+    const t = new CompositeTransport({ primary, fallback });
+    expect((await t.export([rec(Date.UTC(2026, 4, 11, 0), 'a')])).ok).toBe(true);
+    expect(await fallback.listBuckets()).toEqual(['2026-05-11']);
+    await t.shutdown();
+  });
+
+  it('returns ok:false when both primary and fallback fail', async () => {
+    const primary = new StubPrimary();
+    primary.results = [{ ok: false, reason: 'p' }];
+    const fallback = {
+      export: () => Promise.resolve({ ok: false, reason: 'f' }),
+      shutdown: () => Promise.resolve(),
+      listBuckets: () => Promise.resolve([] as string[]),
+      getBucket: () => Promise.resolve([] as LogRecord[]),
+      deleteBucket: () => Promise.resolve(),
+    } as unknown as IndexedDBTransport;
+    const t = new CompositeTransport({ primary, fallback });
+    const r = await t.export([rec(Date.UTC(2026, 4, 11, 0), 'a')]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('p');
+    expect(r.reason).toContain('f');
+  });
+
+  it('shutdown closes both primary and fallback', async () => {
+    const primary = new StubPrimary();
+    const fallback = new IndexedDBTransport();
+    const t = new CompositeTransport({ primary, fallback });
+    await t.shutdown();
+    expect(primary.shutdownCount).toBe(1);
+  });
+});
+
+describe('CompositeTransport.flushFromIdb', () => {
+  it('drains in ascending date order and deletes on success', async () => {
+    const fallback = new IndexedDBTransport();
+    await fallback.export([rec(Date.UTC(2026, 4, 12, 0), 'b')]);
+    await fallback.export([rec(Date.UTC(2026, 4, 11, 0), 'a')]);
+    const primary = new StubPrimary();
+    primary.results = [{ ok: true }, { ok: true }];
+    const t = new CompositeTransport({ primary, fallback });
+    const result = await t.flushFromIdb();
+    expect(result).toEqual({ flushed: 2, remaining: 0 });
+    expect(primary.calls[0]?.map((r) => r.body)).toEqual(['a']);
+    expect(primary.calls[1]?.map((r) => r.body)).toEqual(['b']);
+    expect(await fallback.listBuckets()).toEqual([]);
+    await t.shutdown();
+  });
+
+  it('stops at first failure and does not delete the failed bucket', async () => {
+    const fallback = new IndexedDBTransport();
+    await fallback.export([rec(Date.UTC(2026, 4, 11, 0), 'a')]);
+    await fallback.export([rec(Date.UTC(2026, 4, 12, 0), 'b')]);
+    const primary = new StubPrimary();
+    primary.results = [{ ok: true }, { ok: false, reason: 'down' }];
+    const t = new CompositeTransport({ primary, fallback });
+    const result = await t.flushFromIdb();
+    expect(result).toEqual({ flushed: 1, remaining: 1 });
+    expect(await fallback.listBuckets()).toEqual(['2026-05-12']);
+    await t.shutdown();
+  });
+
+  it('reports zero flushed when no buckets are present', async () => {
+    const fallback = new IndexedDBTransport();
+    const primary = new StubPrimary();
+    const t = new CompositeTransport({ primary, fallback });
+    expect(await t.flushFromIdb()).toEqual({ flushed: 0, remaining: 0 });
+    await t.shutdown();
+  });
+});

--- a/packages/chrome-ext/src/__tests__/logging/indexeddb-transport.test.ts
+++ b/packages/chrome-ext/src/__tests__/logging/indexeddb-transport.test.ts
@@ -1,0 +1,102 @@
+import 'fake-indexeddb/auto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import { IndexedDBTransport } from '../../background/logging/indexeddb-transport';
+import type { LogRecord } from '@mdreview/core/logging';
+
+function rec(timestampMs: number, body: string): LogRecord {
+  return {
+    timestamp: timestampMs * 1_000_000,
+    observedTimestamp: timestampMs * 1_000_000,
+    severityNumber: 9,
+    severityText: 'INFO',
+    body,
+    attributes: {},
+    resource: {
+      'service.name': 'mdview',
+      'service.version': '0',
+      'service.namespace': 'chrome-sw',
+      'deployment.environment': 'dev',
+      'host.os': 't',
+    },
+  };
+}
+
+let openTransports: IndexedDBTransport[] = [];
+
+beforeEach(() => {
+  (globalThis as unknown as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+  openTransports = [];
+});
+
+afterEach(async () => {
+  for (const t of openTransports) {
+    try {
+      await t.shutdown();
+    } catch {
+      /* best-effort */
+    }
+  }
+  openTransports = [];
+});
+
+function track(t: IndexedDBTransport): IndexedDBTransport {
+  openTransports.push(t);
+  return t;
+}
+
+describe('IndexedDBTransport', () => {
+  it('stores records under their date bucket', async () => {
+    const t = track(new IndexedDBTransport());
+    const result = await t.export([
+      rec(Date.UTC(2026, 4, 11, 10), 'a'),
+      rec(Date.UTC(2026, 4, 11, 11), 'b'),
+    ]);
+    expect(result).toEqual({ ok: true });
+    expect(await t.listBuckets()).toEqual(['2026-05-11']);
+    expect((await t.getBucket('2026-05-11')).map((r) => r.body)).toEqual(['a', 'b']);
+  });
+
+  it('listBuckets returns ascending dates', async () => {
+    const t = track(new IndexedDBTransport());
+    await t.export([rec(Date.UTC(2026, 4, 13, 0), 'c')]);
+    await t.export([rec(Date.UTC(2026, 4, 11, 0), 'a'), rec(Date.UTC(2026, 4, 12, 0), 'b')]);
+    expect(await t.listBuckets()).toEqual(['2026-05-11', '2026-05-12', '2026-05-13']);
+  });
+
+  it('deleteBucket removes only the named date', async () => {
+    const t = track(new IndexedDBTransport());
+    await t.export([rec(Date.UTC(2026, 4, 11, 0), 'a'), rec(Date.UTC(2026, 4, 12, 0), 'b')]);
+    await t.deleteBucket('2026-05-11');
+    expect(await t.listBuckets()).toEqual(['2026-05-12']);
+    expect((await t.getBucket('2026-05-12')).map((r) => r.body)).toEqual(['b']);
+  });
+
+  it('survives reopen (new instance sees prior writes)', async () => {
+    const t1 = new IndexedDBTransport();
+    await t1.export([rec(Date.UTC(2026, 4, 11, 0), 'a')]);
+    await t1.shutdown();
+    const t2 = track(new IndexedDBTransport());
+    expect(await t2.listBuckets()).toEqual(['2026-05-11']);
+  });
+
+  it('returns ok:false on transaction error', async () => {
+    const t = new IndexedDBTransport({ dbName: 'forced-fail-test' });
+    const orig = (globalThis as unknown as { indexedDB: unknown }).indexedDB;
+    (globalThis as unknown as { indexedDB: unknown }).indexedDB = {
+      open: () => {
+        const req: {
+          onerror?: (ev: { target: { error: Error } }) => void;
+          onsuccess?: () => void;
+          onupgradeneeded?: () => void;
+        } = {};
+        setTimeout(() => req.onerror?.({ target: { error: new Error('boom') } }), 0);
+        return req;
+      },
+    };
+    const result = await t.export([rec(Date.UTC(2026, 4, 11, 0), 'a')]);
+    expect(result.ok).toBe(false);
+    expect(typeof result.reason).toBe('string');
+    (globalThis as unknown as { indexedDB: unknown }).indexedDB = orig;
+  });
+});

--- a/packages/chrome-ext/src/__tests__/logging/native-host-transport.test.ts
+++ b/packages/chrome-ext/src/__tests__/logging/native-host-transport.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { NativeHostTransport } from '../../background/logging/native-host-transport';
+import type { LogRecord } from '@mdreview/core/logging';
+
+const REC: LogRecord = {
+  timestamp: 1,
+  observedTimestamp: 1,
+  severityNumber: 9,
+  severityText: 'INFO',
+  body: 'x',
+  attributes: {},
+  resource: {
+    'service.name': 'mdview',
+    'service.version': '0',
+    'service.namespace': 'chrome-sw',
+    'deployment.environment': 'dev',
+    'host.os': 't',
+  },
+};
+
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+});
+
+describe('NativeHostTransport', () => {
+  it('returns ok:true on a success response', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendNativeMessage(_h: string, _m: unknown, cb: (r?: unknown) => void) {
+          cb({ success: true });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new NativeHostTransport({ timeoutMs: 100 });
+    expect(await t.export([REC])).toEqual({ ok: true });
+  });
+
+  it('uses the project native host name by default', async () => {
+    let observedHost: string | null = null;
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendNativeMessage(host: string, _m: unknown, cb: (r?: unknown) => void) {
+          observedHost = host;
+          cb({ success: true });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new NativeHostTransport({ timeoutMs: 100 });
+    await t.export([REC]);
+    expect(observedHost).toBe('com.mdreview.filewriter');
+  });
+
+  it('sends a log_batch payload with the records', async () => {
+    let observed: unknown = null;
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendNativeMessage(_h: string, msg: unknown, cb: (r?: unknown) => void) {
+          observed = msg;
+          cb({ success: true });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new NativeHostTransport({ timeoutMs: 100 });
+    await t.export([REC]);
+    expect(observed).toMatchObject({ action: 'log_batch' });
+    const records = (observed as { records: LogRecord[] }).records;
+    expect(records).toHaveLength(1);
+    expect(records[0]?.body).toBe('x');
+  });
+
+  it('returns ok:false reason from chrome.runtime.lastError', async () => {
+    const chromeStub = {
+      runtime: {
+        sendNativeMessage(_h: string, _m: unknown, cb: (r?: unknown) => void) {
+          chromeStub.runtime.lastError = { message: 'host down' };
+          cb();
+        },
+        lastError: undefined as { message: string } | undefined,
+      },
+    };
+    (globalThis as { chrome?: unknown }).chrome = chromeStub;
+    const t = new NativeHostTransport({ timeoutMs: 100 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('host down');
+  });
+
+  it('returns ok:false reason:protocol when response has no success', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendNativeMessage(_h: string, _m: unknown, cb: (r?: unknown) => void) {
+          cb({ error: 'nope' });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new NativeHostTransport({ timeoutMs: 100 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('protocol');
+  });
+
+  it('returns ok:false reason:protocol when response is undefined and no lastError', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendNativeMessage(_h: string, _m: unknown, cb: (r?: unknown) => void) {
+          cb(undefined);
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new NativeHostTransport({ timeoutMs: 100 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('protocol');
+  });
+
+  it('returns timeout when callback is never invoked', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendNativeMessage(_h: string, _m: unknown, _cb: (r?: unknown) => void) {
+          /* never call */
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new NativeHostTransport({ timeoutMs: 20 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('timeout');
+  });
+
+  it('returns ok:false reason when chrome.runtime is unavailable', async () => {
+    delete (globalThis as { chrome?: unknown }).chrome;
+    const t = new NativeHostTransport({ timeoutMs: 20 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(typeof r.reason).toBe('string');
+  });
+});

--- a/packages/chrome-ext/src/__tests__/logging/remote-transport.test.ts
+++ b/packages/chrome-ext/src/__tests__/logging/remote-transport.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { RemoteTransport } from '../../content/logging/remote-transport';
+import type { LogRecord } from '@mdreview/core/logging';
+
+const REC: LogRecord = {
+  timestamp: 1,
+  observedTimestamp: 1,
+  severityNumber: 9,
+  severityText: 'INFO',
+  body: 'hi',
+  attributes: {},
+  resource: {
+    'service.name': 'mdview',
+    'service.version': '0',
+    'service.namespace': 'chrome-content',
+    'deployment.environment': 'dev',
+    'host.os': 't',
+  },
+};
+
+afterEach(() => {
+  delete (globalThis as { chrome?: unknown }).chrome;
+});
+
+describe('RemoteTransport', () => {
+  it('returns ok:true when the SW responds { ok: true }', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendMessage(_m: unknown, cb: (r?: unknown) => void) {
+          cb({ ok: true });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new RemoteTransport({ timeoutMs: 100 });
+    expect(await t.export([REC])).toEqual({ ok: true });
+  });
+
+  it('sends a LOG_BATCH message with the records', async () => {
+    let observed: unknown = null;
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendMessage(msg: unknown, cb: (r?: unknown) => void) {
+          observed = msg;
+          cb({ ok: true });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new RemoteTransport({ timeoutMs: 100 });
+    await t.export([REC]);
+    expect(observed).toMatchObject({ type: 'LOG_BATCH' });
+    const records = (observed as { records: LogRecord[] }).records;
+    expect(records).toHaveLength(1);
+    expect(records[0]?.body).toBe('hi');
+  });
+
+  it('returns ok:false with chrome.runtime.lastError message', async () => {
+    const chromeStub = {
+      runtime: {
+        sendMessage(_m: unknown, cb: (r?: unknown) => void) {
+          chromeStub.runtime.lastError = { message: 'no SW' };
+          cb();
+        },
+        lastError: undefined as { message: string } | undefined,
+      },
+    };
+    (globalThis as { chrome?: unknown }).chrome = chromeStub;
+    const t = new RemoteTransport({ timeoutMs: 100 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('no SW');
+  });
+
+  it('returns ok:false reason:protocol when response has no ok', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendMessage(_m: unknown, cb: (r?: unknown) => void) {
+          cb({ error: 'nope' });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new RemoteTransport({ timeoutMs: 100 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('protocol');
+  });
+
+  it('returns the SW-provided reason when ok is false', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendMessage(_m: unknown, cb: (r?: unknown) => void) {
+          cb({ ok: false, reason: 'sw failed' });
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new RemoteTransport({ timeoutMs: 100 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('sw failed');
+  });
+
+  it('returns timeout when callback is never invoked', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendMessage(_m: unknown, _cb: (r?: unknown) => void) {
+          /* never call */
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new RemoteTransport({ timeoutMs: 20 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('timeout');
+  });
+
+  it('returns ok:false reason when sendMessage throws synchronously', async () => {
+    (globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        sendMessage() {
+          throw new Error('extension context invalidated');
+        },
+        lastError: undefined,
+      },
+    };
+    const t = new RemoteTransport({ timeoutMs: 100 });
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain('extension context invalidated');
+  });
+});

--- a/packages/chrome-ext/src/__tests__/logging/sw-init.test.ts
+++ b/packages/chrome-ext/src/__tests__/logging/sw-init.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleLogBatchMessage } from '../../background/logging/sw-init';
+import type { LogRecord } from '@mdreview/core/logging';
+
+const REC: LogRecord = {
+  timestamp: 1,
+  observedTimestamp: 1,
+  severityNumber: 9,
+  severityText: 'INFO',
+  body: 'hi',
+  attributes: {},
+  resource: {
+    'service.name': 'mdview',
+    'service.version': '0',
+    'service.namespace': 'chrome-sw',
+    'deployment.environment': 'dev',
+    'host.os': 't',
+  },
+};
+
+describe('handleLogBatchMessage', () => {
+  it('forwards records to the transport and returns ok:true on success', async () => {
+    const exportFn = vi.fn().mockResolvedValue({ ok: true });
+    const result = await handleLogBatchMessage({ export: exportFn }, { records: [REC] });
+    expect(exportFn).toHaveBeenCalledWith([REC]);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns ok:false with reason when transport fails', async () => {
+    const exportFn = vi.fn().mockResolvedValue({ ok: false, reason: 'down' });
+    const result = await handleLogBatchMessage({ export: exportFn }, { records: [REC] });
+    expect(result).toEqual({ ok: false, reason: 'down' });
+  });
+
+  it('returns ok:false when transport rejects', async () => {
+    const exportFn = vi.fn().mockRejectedValue(new Error('boom'));
+    const result = await handleLogBatchMessage({ export: exportFn }, { records: [REC] });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('boom');
+  });
+
+  it('rejects payloads where records is not an array', async () => {
+    const exportFn = vi.fn();
+    const result = await handleLogBatchMessage(
+      { export: exportFn },
+      { records: 'nope' as unknown }
+    );
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/array/i);
+    expect(exportFn).not.toHaveBeenCalled();
+  });
+
+  it('rejects payloads where records is missing', async () => {
+    const exportFn = vi.fn();
+    const result = await handleLogBatchMessage({ export: exportFn }, {});
+    expect(result.ok).toBe(false);
+    expect(exportFn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/chrome-ext/src/background/logging/bridge-recovery.ts
+++ b/packages/chrome-ext/src/background/logging/bridge-recovery.ts
@@ -1,0 +1,96 @@
+import type { BridgeHealth } from '@mdreview/core';
+import type { CompositeTransport } from './composite-transport';
+
+export interface BridgeRecoveryOpts {
+  bridge: Pick<BridgeHealth, 'onStateChange'>;
+  transport: Pick<CompositeTransport, 'flushFromIdb'>;
+  /** Debounce window in milliseconds. Defaults to 1000. */
+  debounceMs?: number;
+  /** Optional injection points for tests. */
+  scheduleTimeout?: (cb: () => void, ms: number) => unknown;
+  clearTimeout?: (handle: unknown) => void;
+}
+
+export interface BridgeRecovery {
+  start(): void;
+  stop(): void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 1000;
+
+/**
+ * Watches bridge-health state transitions and triggers a buffered-log flush
+ * each time the bridge re-enters the `connected` state.
+ *
+ * The flush is debounced so a flapping bridge does not thrash the native
+ * messaging host. Transitions out of `connected` cancel any pending flush;
+ * a subsequent `connected` re-arms the debounce window.
+ *
+ * Errors from `flushFromIdb` are caught and logged to `console.warn` because
+ * the recovery loop runs before the logger stack itself is fully wired and we
+ * must not push exceptions through Chrome's event listeners.
+ */
+export function createBridgeRecovery(opts: BridgeRecoveryOpts): BridgeRecovery {
+  const debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const schedule =
+    opts.scheduleTimeout ??
+    ((cb: () => void, ms: number) =>
+      (globalThis as { setTimeout: typeof setTimeout }).setTimeout(cb, ms));
+  const cancel =
+    opts.clearTimeout ??
+    ((handle: unknown) =>
+      (globalThis as { clearTimeout: typeof clearTimeout }).clearTimeout(
+        handle as ReturnType<typeof setTimeout>
+      ));
+
+  let stopped = false;
+  let pending: unknown = null;
+  let started = false;
+
+  function clearPending(): void {
+    if (pending !== null) {
+      cancel(pending);
+      pending = null;
+    }
+  }
+
+  function runFlush(): void {
+    pending = null;
+    if (stopped) return;
+    try {
+      const result = opts.transport.flushFromIdb();
+      // flushFromIdb returns a Promise; swallow any rejection.
+      void Promise.resolve(result).catch((err) => {
+        // eslint-disable-next-line no-console
+        console.warn('[bridge-recovery] flushFromIdb rejected:', err);
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn('[bridge-recovery] flushFromIdb threw:', err);
+    }
+  }
+
+  function onState(state: 'connected' | 'reconnecting' | 'disconnected'): void {
+    if (stopped) return;
+    if (state === 'connected') {
+      clearPending();
+      pending = schedule(runFlush, debounceMs);
+      return;
+    }
+    // Any transition out of connected cancels the pending flush. We re-arm
+    // on the next connect.
+    clearPending();
+  }
+
+  return {
+    start(): void {
+      if (started) return;
+      started = true;
+      opts.bridge.onStateChange(onState);
+    },
+    stop(): void {
+      stopped = true;
+      clearPending();
+    },
+  };
+}

--- a/packages/chrome-ext/src/background/logging/composite-transport.ts
+++ b/packages/chrome-ext/src/background/logging/composite-transport.ts
@@ -1,0 +1,67 @@
+import type { LogRecord, LogTransport, TransportResult } from '@mdreview/core/logging';
+import type { IndexedDBTransport } from './indexeddb-transport';
+
+export interface CompositeTransportOpts {
+  primary: LogTransport;
+  fallback: IndexedDBTransport;
+}
+
+/**
+ * Layers a primary transport (native host) over an IndexedDB fallback so the
+ * Chrome extension never silently drops a batch when the bridge is down.
+ *
+ * On a failed primary export, records are persisted to IDB and the caller is
+ * told the batch was accepted. `flushFromIdb` drains buffered buckets back
+ * through the primary once the bridge recovers.
+ */
+export class CompositeTransport implements LogTransport {
+  private readonly primary: LogTransport;
+  private readonly fallback: IndexedDBTransport;
+
+  constructor(opts: CompositeTransportOpts) {
+    this.primary = opts.primary;
+    this.fallback = opts.fallback;
+  }
+
+  async export(records: readonly LogRecord[]): Promise<TransportResult> {
+    const primaryResult = await this.primary.export(records);
+    if (primaryResult.ok) return { ok: true };
+
+    const fallbackResult = await this.fallback.export(records);
+    if (fallbackResult.ok) return { ok: true };
+
+    const primaryReason = primaryResult.reason ?? 'unknown';
+    const fallbackReason = fallbackResult.reason ?? 'unknown';
+    return {
+      ok: false,
+      reason: `primary: ${primaryReason}, fallback: ${fallbackReason}`,
+    };
+  }
+
+  /**
+   * Drain buffered IDB buckets through the primary transport in ascending
+   * date order. Stops at the first transport failure, leaving the failed
+   * bucket and any later ones in place for the next attempt.
+   */
+  async flushFromIdb(): Promise<{ flushed: number; remaining: number }> {
+    const dates = await this.fallback.listBuckets();
+    let flushed = 0;
+    for (const date of dates) {
+      const records = await this.fallback.getBucket(date);
+      const result = await this.primary.export(records);
+      if (!result.ok) {
+        return { flushed, remaining: dates.length - flushed };
+      }
+      await this.fallback.deleteBucket(date);
+      flushed++;
+    }
+    return { flushed, remaining: dates.length - flushed };
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.primary.shutdown) {
+      await this.primary.shutdown();
+    }
+    await this.fallback.shutdown();
+  }
+}

--- a/packages/chrome-ext/src/background/logging/indexeddb-transport.ts
+++ b/packages/chrome-ext/src/background/logging/indexeddb-transport.ts
@@ -1,0 +1,200 @@
+import type { LogRecord, LogTransport, TransportResult } from '@mdreview/core/logging';
+
+const DEFAULT_DB_NAME = 'mdview-logs';
+const DB_VERSION = 1;
+const STORE = 'records';
+const INDEX_BY_DATE = 'by_date';
+
+interface StoredRecord {
+  _date: string;
+  record: LogRecord;
+}
+
+/**
+ * Persistent IndexedDB-backed fallback for the Chrome extension log pipeline.
+ *
+ * Records are bucketed by UTC date stem so the composite transport can drain
+ * them in chronological order when the primary (native host) recovers.
+ */
+export class IndexedDBTransport implements LogTransport {
+  private readonly dbName: string;
+  private dbPromise: Promise<IDBDatabase> | null = null;
+
+  constructor(opts?: { dbName?: string }) {
+    this.dbName = opts?.dbName ?? DEFAULT_DB_NAME;
+  }
+
+  async export(records: readonly LogRecord[]): Promise<TransportResult> {
+    if (records.length === 0) return { ok: true };
+    try {
+      const db = await this.getDb();
+      await runTransaction(db, 'readwrite', (store) => {
+        for (const record of records) {
+          const value: StoredRecord = { _date: dateStem(record.timestamp), record };
+          store.add(value);
+        }
+      });
+      return { ok: true };
+    } catch (err) {
+      // Reset cached connection so a future call can retry from scratch.
+      this.dbPromise = null;
+      return { ok: false, reason: errorReason(err) };
+    }
+  }
+
+  async listBuckets(): Promise<string[]> {
+    const db = await this.getDb();
+    const dates = new Set<string>();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readonly');
+      const store = tx.objectStore(STORE);
+      const index = store.index(INDEX_BY_DATE);
+      const req = index.openKeyCursor();
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          dates.add(String(cursor.key));
+          cursor.continue();
+        }
+      };
+      req.onerror = () => reject(req.error ?? new Error('cursor failed'));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('transaction failed'));
+      tx.onabort = () => reject(tx.error ?? new Error('transaction aborted'));
+    });
+    return [...dates].sort();
+  }
+
+  async getBucket(date: string): Promise<LogRecord[]> {
+    const db = await this.getDb();
+    const out: LogRecord[] = [];
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readonly');
+      const store = tx.objectStore(STORE);
+      const index = store.index(INDEX_BY_DATE);
+      const req = index.openCursor(IDBKeyRange.only(date));
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          const value = cursor.value as StoredRecord;
+          out.push(value.record);
+          cursor.continue();
+        }
+      };
+      req.onerror = () => reject(req.error ?? new Error('cursor failed'));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('transaction failed'));
+      tx.onabort = () => reject(tx.error ?? new Error('transaction aborted'));
+    });
+    return out;
+  }
+
+  async deleteBucket(date: string): Promise<void> {
+    const db = await this.getDb();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite');
+      const store = tx.objectStore(STORE);
+      const index = store.index(INDEX_BY_DATE);
+      const req = index.openCursor(IDBKeyRange.only(date));
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          cursor.delete();
+          cursor.continue();
+        }
+      };
+      req.onerror = () => reject(req.error ?? new Error('cursor failed'));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error('transaction failed'));
+      tx.onabort = () => reject(tx.error ?? new Error('transaction aborted'));
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.dbPromise) return;
+    try {
+      const db = await this.dbPromise;
+      db.close();
+    } catch {
+      /* best-effort */
+    }
+    this.dbPromise = null;
+  }
+
+  private getDb(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = openDb(this.dbName).catch((err) => {
+        this.dbPromise = null;
+        throw err;
+      });
+    }
+    return this.dbPromise;
+  }
+}
+
+function openDb(name: string): Promise<IDBDatabase> {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const idb = (globalThis as unknown as { indexedDB: IDBFactory | undefined }).indexedDB;
+    if (!idb) {
+      reject(new Error('indexedDB unavailable'));
+      return;
+    }
+    const req = idb.open(name, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { autoIncrement: true });
+        store.createIndex(INDEX_BY_DATE, '_date', { unique: false });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('open failed'));
+    req.onblocked = () => reject(new Error('open blocked'));
+  });
+}
+
+function runTransaction(
+  db: IDBDatabase,
+  mode: IDBTransactionMode,
+  work: (store: IDBObjectStore) => void
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let tx: IDBTransaction;
+    try {
+      tx = db.transaction(STORE, mode);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const store = tx.objectStore(STORE);
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error ?? new Error('transaction failed'));
+    tx.onabort = () => reject(tx.error ?? new Error('transaction aborted'));
+    try {
+      work(store);
+    } catch (err) {
+      try {
+        tx.abort();
+      } catch {
+        /* ignore */
+      }
+      reject(err);
+    }
+  });
+}
+
+/** Convert a nanosecond timestamp to a YYYY-MM-DD UTC date stem. */
+function dateStem(timestampNs: number): string {
+  const ms = Math.floor(timestampNs / 1_000_000);
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+function errorReason(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return 'unknown error';
+  }
+}

--- a/packages/chrome-ext/src/background/logging/native-host-transport.ts
+++ b/packages/chrome-ext/src/background/logging/native-host-transport.ts
@@ -1,0 +1,103 @@
+import type { LogRecord, LogTransport, TransportResult } from '@mdreview/core/logging';
+
+const DEFAULT_HOST_NAME = 'com.mdreview.filewriter';
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export interface NativeHostTransportOpts {
+  /** Native messaging host id. Defaults to the mdview file writer host. */
+  hostName?: string;
+  /** Per-batch timeout in milliseconds. Defaults to 5000. */
+  timeoutMs?: number;
+}
+
+interface ChromeRuntimeLike {
+  sendNativeMessage(host: string, message: unknown, callback: (response?: unknown) => void): void;
+  lastError?: { message?: string };
+}
+
+/**
+ * Primary Chrome log transport. Sends batches to the native messaging host
+ * as `{ action: 'log_batch', records }` and resolves with the outcome.
+ *
+ * The transport never throws; transport failure is always communicated as
+ * `{ ok: false, reason }` so the composite transport can fall back without
+ * losing records.
+ */
+export class NativeHostTransport implements LogTransport {
+  private readonly hostName: string;
+  private readonly timeoutMs: number;
+
+  constructor(opts?: NativeHostTransportOpts) {
+    this.hostName = opts?.hostName ?? DEFAULT_HOST_NAME;
+    this.timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  export(records: readonly LogRecord[]): Promise<TransportResult> {
+    return new Promise<TransportResult>((resolve) => {
+      const runtime = getRuntime();
+      if (!runtime) {
+        resolve({ ok: false, reason: 'chrome.runtime unavailable' });
+        return;
+      }
+
+      const message = { action: 'log_batch', records: [...records] };
+      let settled = false;
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        resolve({ ok: false, reason: 'timeout' });
+      }, this.timeoutMs);
+
+      const finish = (result: TransportResult) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+
+      try {
+        runtime.sendNativeMessage(this.hostName, message, (response?: unknown) => {
+          // Re-read runtime after the callback because chrome stamps
+          // lastError on the runtime object synchronously inside the cb.
+          const post = getRuntime();
+          const lastError = post?.lastError;
+          if (lastError) {
+            finish({ ok: false, reason: lastError.message ?? 'lastError' });
+            return;
+          }
+          if (!isSuccessResponse(response)) {
+            finish({ ok: false, reason: 'protocol' });
+            return;
+          }
+          finish({ ok: true });
+        });
+      } catch (err) {
+        finish({ ok: false, reason: errorReason(err) });
+      }
+    });
+  }
+}
+
+function getRuntime(): ChromeRuntimeLike | undefined {
+  const c = (globalThis as { chrome?: { runtime?: ChromeRuntimeLike } }).chrome;
+  return c?.runtime;
+}
+
+function isSuccessResponse(response: unknown): boolean {
+  return (
+    response !== null &&
+    typeof response === 'object' &&
+    (response as { success?: unknown }).success === true
+  );
+}
+
+function errorReason(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return 'unknown error';
+  }
+}

--- a/packages/chrome-ext/src/background/logging/sw-init.ts
+++ b/packages/chrome-ext/src/background/logging/sw-init.ts
@@ -1,0 +1,79 @@
+import {
+  initLogging,
+  type LogRecord,
+  type LogTransport,
+  type ResourceAttrs,
+  type TransportResult,
+} from '@mdreview/core/logging';
+import type { BridgeHealth } from '@mdreview/core';
+import { CompositeTransport } from './composite-transport';
+import { IndexedDBTransport } from './indexeddb-transport';
+import { NativeHostTransport } from './native-host-transport';
+import { createBridgeRecovery, type BridgeRecovery } from './bridge-recovery';
+
+export interface SwLoggingHandles {
+  transport: CompositeTransport;
+  recovery: BridgeRecovery;
+}
+
+export interface InitSwLoggingOpts {
+  bridge: Pick<BridgeHealth, 'onStateChange'>;
+  version: string;
+  /** Optional override for tests. */
+  transport?: CompositeTransport;
+}
+
+/**
+ * Wire the service worker logger:
+ *  - native-host primary transport
+ *  - IndexedDB fallback buffer
+ *  - composite transport that falls back on primary failure
+ *  - bridge-recovery flusher that drains buffered logs on reconnect
+ */
+export function initSwLogging(opts: InitSwLoggingOpts): SwLoggingHandles {
+  const transport =
+    opts.transport ??
+    new CompositeTransport({
+      primary: new NativeHostTransport(),
+      fallback: new IndexedDBTransport(),
+    });
+
+  const resource: ResourceAttrs = {
+    'service.name': 'mdview',
+    'service.version': opts.version,
+    'service.namespace': 'chrome-sw',
+    'deployment.environment': 'prod',
+    'host.os': 'unknown',
+  };
+
+  initLogging({ transport, resource });
+
+  const recovery = createBridgeRecovery({ bridge: opts.bridge, transport });
+  recovery.start();
+
+  return { transport, recovery };
+}
+
+/**
+ * Handle a single `LOG_BATCH` message on the service worker side. Returns a
+ * response shape compatible with `RemoteTransport`'s expectations:
+ * `{ ok: boolean, reason?: string }`.
+ *
+ * Exported so unit tests can exercise the routing in isolation from the
+ * `chrome.runtime.onMessage` listener.
+ */
+export async function handleLogBatchMessage(
+  transport: Pick<LogTransport, 'export'>,
+  payload: { records?: unknown }
+): Promise<{ ok: boolean; reason?: string }> {
+  if (!Array.isArray(payload.records)) {
+    return { ok: false, reason: 'records must be an array' };
+  }
+  try {
+    const result: TransportResult = await transport.export(payload.records as readonly LogRecord[]);
+    if (result.ok) return { ok: true };
+    return { ok: false, reason: result.reason ?? 'unknown' };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/chrome-ext/src/background/service-worker.ts
+++ b/packages/chrome-ext/src/background/service-worker.ts
@@ -8,6 +8,7 @@ import { CacheManager, DEFAULT_STATE } from '@mdreview/core/sw';
 import { debug } from '../utils/debug-logger';
 import { ChromeBridgeHealth } from './bridge-health';
 import { sendFramedMessage } from './message-frame';
+import { handleLogBatchMessage, initSwLogging } from './logging/sw-init';
 
 // Cache management (persists across page reloads)
 const cacheManager = new CacheManager({ maxSize: 50, maxAge: 3600000 });
@@ -104,6 +105,14 @@ const stateManager = new StateManager();
 const bridgeHealth = new ChromeBridgeHealth();
 let bridgeSeqCounter = 0;
 
+// Logging: wire native-host primary + IndexedDB fallback + bridge-recovery flusher.
+// Initialised at SW load so loggers obtained before message handling flush to
+// the real transport instead of staying in the pre-init ring buffer.
+const swLogging = initSwLogging({
+  bridge: bridgeHealth,
+  version: chrome.runtime.getManifest().version,
+});
+
 // Broadcast bridge state changes to all tabs
 bridgeHealth.onStateChange((newState) => {
   debug.log('MDView', 'Bridge state changed:', newState);
@@ -195,8 +204,25 @@ chrome.runtime.onStartup.addListener(() => {
 
 // Message handler
 chrome.runtime.onMessage.addListener(
-  (message: { type: string; payload?: unknown }, sender, sendResponse) => {
+  (message: { type: string; payload?: unknown; records?: unknown }, sender, sendResponse) => {
     debug.log('MDView', 'Received message:', message.type, 'from:', sender.tab?.id);
+
+    // LOG_BATCH is hot-path; resolve before awaiting state init so loggers in
+    // content/popup contexts don't block on storage I/O.
+    if (message.type === 'LOG_BATCH') {
+      void (async () => {
+        try {
+          const result = await handleLogBatchMessage(swLogging.transport, {
+            records: message.records,
+          });
+          sendResponse(result);
+        } catch (error) {
+          debug.error('MDView', 'LOG_BATCH route threw:', error);
+          sendResponse({ ok: false, reason: String(error) });
+        }
+      })();
+      return true;
+    }
 
     void (async () => {
       try {

--- a/packages/chrome-ext/src/content/content-script.ts
+++ b/packages/chrome-ext/src/content/content-script.ts
@@ -12,6 +12,17 @@ import { TocRenderer } from '@mdreview/core';
 import type { ExportUI } from '../ui/export-ui';
 import type { CommentManager } from '../comments/comment-manager';
 import { BridgeIndicator } from './bridge-indicator';
+import { initRemoteLogging } from './logging/init';
+
+// Initialise the structured logger as soon as the content script loads so
+// records emitted during page setup go through the SW route instead of the
+// pre-init ring buffer.
+try {
+  initRemoteLogging('chrome-content', chrome.runtime.getManifest().version);
+} catch (error) {
+  // eslint-disable-next-line no-console
+  console.warn('[MDView] initRemoteLogging failed:', error);
+}
 
 // Fix Vite's dynamic import base path for Chrome extensions
 // Override import.meta to use chrome-extension:// base URL

--- a/packages/chrome-ext/src/content/logging/init.ts
+++ b/packages/chrome-ext/src/content/logging/init.ts
@@ -1,0 +1,21 @@
+import { initLogging, type ResourceAttrs } from '@mdreview/core/logging';
+import { RemoteTransport } from './remote-transport';
+
+export type ChromeContextNamespace = 'chrome-content' | 'chrome-ext';
+
+/**
+ * Initialise the logger for a non-SW Chrome context (content script or popup).
+ * Builds a `RemoteTransport` that forwards every batch to the service worker
+ * as a `LOG_BATCH` message; the SW owns the native-host + IndexedDB plumbing.
+ */
+export function initRemoteLogging(namespace: ChromeContextNamespace, version: string): void {
+  const transport = new RemoteTransport();
+  const resource: ResourceAttrs = {
+    'service.name': 'mdview',
+    'service.version': version,
+    'service.namespace': namespace,
+    'deployment.environment': 'prod',
+    'host.os': 'unknown',
+  };
+  initLogging({ transport, resource });
+}

--- a/packages/chrome-ext/src/content/logging/remote-transport.ts
+++ b/packages/chrome-ext/src/content/logging/remote-transport.ts
@@ -1,0 +1,100 @@
+import type { LogRecord, LogTransport, TransportResult } from '@mdreview/core/logging';
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export interface RemoteTransportOpts {
+  /** Per-batch timeout in milliseconds. Defaults to 5000. */
+  timeoutMs?: number;
+}
+
+interface ChromeRuntimeLike {
+  sendMessage(message: unknown, callback: (response?: unknown) => void): void;
+  lastError?: { message?: string };
+}
+
+/**
+ * `LogTransport` for content scripts and the popup. Forwards each batch to
+ * the service worker as a `LOG_BATCH` message; the SW owns the actual
+ * native-host / IndexedDB plumbing.
+ *
+ * Like the other Chrome transports, this never throws; failures surface as
+ * `{ ok: false, reason }` so upstream code can decide what to do.
+ */
+export class RemoteTransport implements LogTransport {
+  private readonly timeoutMs: number;
+
+  constructor(opts?: RemoteTransportOpts) {
+    this.timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  }
+
+  export(records: readonly LogRecord[]): Promise<TransportResult> {
+    return new Promise<TransportResult>((resolve) => {
+      const runtime = getRuntime();
+      if (!runtime) {
+        resolve({ ok: false, reason: 'chrome.runtime unavailable' });
+        return;
+      }
+
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        resolve({ ok: false, reason: 'timeout' });
+      }, this.timeoutMs);
+
+      const finish = (result: TransportResult): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+
+      const message = { type: 'LOG_BATCH', records: [...records] };
+      try {
+        runtime.sendMessage(message, (response?: unknown) => {
+          const post = getRuntime();
+          const lastError = post?.lastError;
+          if (lastError) {
+            finish({ ok: false, reason: lastError.message ?? 'lastError' });
+            return;
+          }
+          if (!isObject(response)) {
+            finish({ ok: false, reason: 'protocol' });
+            return;
+          }
+          const ok = (response as { ok?: unknown }).ok;
+          if (ok === true) {
+            finish({ ok: true });
+            return;
+          }
+          const reason = (response as { reason?: unknown }).reason;
+          finish({
+            ok: false,
+            reason: typeof reason === 'string' ? reason : 'protocol',
+          });
+        });
+      } catch (err) {
+        finish({ ok: false, reason: errorReason(err) });
+      }
+    });
+  }
+}
+
+function getRuntime(): ChromeRuntimeLike | undefined {
+  const c = (globalThis as { chrome?: { runtime?: ChromeRuntimeLike } }).chrome;
+  return c?.runtime;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object';
+}
+
+function errorReason(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return 'unknown error';
+  }
+}

--- a/packages/chrome-ext/src/native-host/host-logic.test.ts
+++ b/packages/chrome-ext/src/native-host/host-logic.test.ts
@@ -11,6 +11,8 @@ vi.mock('fs', () => ({
 
 vi.mock('os', () => ({
   userInfo: vi.fn(),
+  // tmpdir is consulted by the log_batch action; route to a real tmp path.
+  tmpdir: vi.fn(() => '/tmp'),
 }));
 
 describe('host-logic', () => {
@@ -90,6 +92,30 @@ describe('host-logic', () => {
     it('returns error for unknown action', () => {
       const result = handleMessage({ action: 'unknown' } as HostMessage);
       expect(result).toEqual({ error: 'Unknown action: unknown' });
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // log_batch action
+  // -----------------------------------------------------------------------
+
+  describe('log_batch action', () => {
+    it('returns success for an empty records array', () => {
+      const result = handleMessage({ action: 'log_batch', records: [] } as HostMessage);
+      expect(result).toMatchObject({ success: true });
+    });
+
+    it('rejects non-array records', () => {
+      const result = handleMessage({
+        action: 'log_batch',
+        records: 'not an array',
+      } as unknown as HostMessage);
+      expect(result).toMatchObject({ error: expect.stringMatching(/array/i) as unknown });
+    });
+
+    it('rejects missing records field', () => {
+      const result = handleMessage({ action: 'log_batch' } as HostMessage);
+      expect(result).toMatchObject({ error: expect.stringMatching(/array/i) as unknown });
     });
   });
 

--- a/packages/chrome-ext/src/native-host/host-logic.ts
+++ b/packages/chrome-ext/src/native-host/host-logic.ts
@@ -9,6 +9,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { writeLogBatch } from './log-writer';
 
 export const ALLOWED_EXTENSIONS = ['.md', '.markdown', '.mdx'];
 
@@ -27,7 +28,12 @@ export interface PingMessage {
   seq?: number;
 }
 
-export type HostMessage = WriteMessage | GetUsernameMessage | PingMessage;
+export interface LogBatchMessage {
+  action: 'log_batch';
+  records?: unknown[];
+}
+
+export type HostMessage = WriteMessage | GetUsernameMessage | PingMessage | LogBatchMessage;
 
 export interface SuccessResponse {
   success: true;
@@ -75,6 +81,21 @@ export function handleMessage(msg: HostMessage | null | string): HostResponse {
   if (msg.action === 'get_username') {
     try {
       return { success: true, username: os.userInfo().username };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { error: message };
+    }
+  }
+
+  if (msg.action === 'log_batch') {
+    const logMsg = msg as LogBatchMessage;
+    if (!Array.isArray(logMsg.records)) {
+      return { error: 'log_batch: records must be an array' };
+    }
+    try {
+      const dir = path.join(os.tmpdir(), 'mdview', 'logs');
+      writeLogBatch(logMsg.records, { dir });
+      return { success: true };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       return { error: message };

--- a/packages/chrome-ext/src/native-host/log-writer.test.ts
+++ b/packages/chrome-ext/src/native-host/log-writer.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeLogBatch } from './log-writer';
+
+function makeRecord(body: string): Record<string, unknown> {
+  return {
+    timestamp: 1,
+    observedTimestamp: 1,
+    severityNumber: 9,
+    severityText: 'INFO',
+    body,
+    attributes: {},
+    resource: {
+      'service.name': 'mdview',
+      'service.version': '0',
+      'service.namespace': 'chrome-sw',
+      'deployment.environment': 'dev',
+      'host.os': 't',
+    },
+  };
+}
+
+describe('writeLogBatch', () => {
+  it('appends records as JSONL to mdview-chrome-YYYY-MM-DD.jsonl', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mdview-host-log-'));
+    try {
+      const records = [makeRecord('hi'), makeRecord('there')];
+      const today = new Date('2026-05-11T12:00:00Z');
+      writeLogBatch(records, { dir, today });
+      const file = join(dir, 'mdview-chrome-2026-05-11.jsonl');
+      const lines = readFileSync(file, 'utf8').trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect((JSON.parse(lines[0]) as { body: string }).body).toBe('hi');
+      expect((JSON.parse(lines[1]) as { body: string }).body).toBe('there');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates the log directory recursively if missing', () => {
+    const base = mkdtempSync(join(tmpdir(), 'mdview-host-log-'));
+    const dir = join(base, 'a', 'b', 'c');
+    try {
+      const today = new Date('2026-05-11T12:00:00Z');
+      writeLogBatch([makeRecord('x')], { dir, today });
+      const file = join(dir, 'mdview-chrome-2026-05-11.jsonl');
+      expect(readFileSync(file, 'utf8')).toContain('"body":"x"');
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('appends to an existing file rather than overwriting', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mdview-host-log-'));
+    try {
+      const today = new Date('2026-05-11T12:00:00Z');
+      writeLogBatch([makeRecord('first')], { dir, today });
+      writeLogBatch([makeRecord('second')], { dir, today });
+      const file = join(dir, 'mdview-chrome-2026-05-11.jsonl');
+      const lines = readFileSync(file, 'utf8').trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect((JSON.parse(lines[0]) as { body: string }).body).toBe('first');
+      expect((JSON.parse(lines[1]) as { body: string }).body).toBe('second');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rotates by size when the current file would exceed maxBytes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mdview-host-log-'));
+    try {
+      const today = new Date('2026-05-11T12:00:00Z');
+      // Pre-seed the current file near the cap so a small append rolls it.
+      const current = join(dir, 'mdview-chrome-2026-05-11.jsonl');
+      writeFileSync(current, 'x'.repeat(1024), 'utf8');
+      writeLogBatch([makeRecord('after-rotate')], {
+        dir,
+        today,
+        maxBytes: 1024,
+      });
+      const names = readdirSync(dir).sort();
+      expect(names).toContain('mdview-chrome-2026-05-11.jsonl');
+      expect(names).toContain('mdview-chrome-2026-05-11.jsonl.1');
+      // The rotated old file keeps its pre-existing content; new file has the new record.
+      const rotated = readFileSync(join(dir, 'mdview-chrome-2026-05-11.jsonl.1'), 'utf8');
+      expect(rotated.length).toBeGreaterThanOrEqual(1024);
+      const fresh = readFileSync(current, 'utf8');
+      expect(fresh).toContain('"body":"after-rotate"');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rotates by date when the current file has a different date stem', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mdview-host-log-'));
+    try {
+      const yesterday = new Date('2026-05-10T12:00:00Z');
+      writeLogBatch([makeRecord('old')], { dir, today: yesterday });
+      const today = new Date('2026-05-11T12:00:00Z');
+      writeLogBatch([makeRecord('new')], { dir, today });
+      const names = readdirSync(dir).sort();
+      expect(names).toContain('mdview-chrome-2026-05-10.jsonl');
+      expect(names).toContain('mdview-chrome-2026-05-11.jsonl');
+      expect(readFileSync(join(dir, 'mdview-chrome-2026-05-11.jsonl'), 'utf8')).toContain(
+        '"body":"new"'
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes files older than retentionDays', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mdview-host-log-'));
+    try {
+      // Seed an ancient file 30 days before today.
+      const ancient = join(dir, 'mdview-chrome-2026-04-01.jsonl');
+      writeFileSync(ancient, '{}\n', 'utf8');
+      const today = new Date('2026-05-11T12:00:00Z');
+      writeLogBatch([makeRecord('current')], { dir, today, retentionDays: 14 });
+      const names = readdirSync(dir);
+      expect(names).not.toContain('mdview-chrome-2026-04-01.jsonl');
+      expect(names).toContain('mdview-chrome-2026-05-11.jsonl');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores non-object records gracefully (no throw, no write)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mdview-host-log-'));
+    try {
+      const today = new Date('2026-05-11T12:00:00Z');
+      // Mixed: one valid, one invalid. Both pass through JSON.stringify as written.
+      writeLogBatch([makeRecord('ok'), null as unknown as Record<string, unknown>], {
+        dir,
+        today,
+      });
+      const file = join(dir, 'mdview-chrome-2026-05-11.jsonl');
+      const lines = readFileSync(file, 'utf8').trim().split('\n');
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/chrome-ext/src/native-host/log-writer.ts
+++ b/packages/chrome-ext/src/native-host/log-writer.ts
@@ -1,0 +1,142 @@
+/**
+ * Self-contained log writer for the native messaging host.
+ *
+ * The native host is bundled as a single CJS file (host.cjs) and is launched
+ * by Chrome with a synchronous request/response shape. We deliberately do not
+ * import `@mdreview/core` here so the host stays minimal and avoids pulling
+ * the renderer-side dependency graph into the host bundle.
+ *
+ * The rotation and prune logic mirrors the pure helpers in
+ * `@mdreview/core/logging` (`currentFileName`, `planRotation`, `planPrune`),
+ * inlined so this file is independent.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+const SOURCE = 'chrome';
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+const MS_PER_DAY = 86_400_000;
+
+export interface WriteLogBatchOpts {
+  /** Target log directory. Created recursively if missing. */
+  dir: string;
+  /** Date used for the file stem. Tests inject a fixed Date. */
+  today?: Date;
+  /** Maximum bytes per file before size rollover. Defaults to 10 MB. */
+  maxBytes?: number;
+  /** Retain files newer than this many days. Defaults to 14. */
+  retentionDays?: number;
+}
+
+function dateStem(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function currentFileName(today: Date): string {
+  return `mdview-${SOURCE}-${dateStem(today)}.jsonl`;
+}
+
+const SOURCE_REGEX = new RegExp(`^mdview-${SOURCE}-(\\d{4}-\\d{2}-\\d{2})\\.jsonl(?:\\.\\d+)?$`);
+
+function nextSizeSuffix(names: readonly string[], baseName: string): number {
+  const prefix = `${baseName}.`;
+  const used = new Set<number>();
+  for (const name of names) {
+    if (!name.startsWith(prefix)) continue;
+    const tail = name.slice(prefix.length);
+    if (!/^\d+$/.test(tail)) continue;
+    const n = Number.parseInt(tail, 10);
+    if (n > 0) used.add(n);
+  }
+  let n = 1;
+  while (used.has(n)) n += 1;
+  return n;
+}
+
+function pickPruneTargets(names: readonly string[], today: Date, retentionDays: number): string[] {
+  const todayMs = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+  const cutoffMs = todayMs - retentionDays * MS_PER_DAY;
+  const out: string[] = [];
+  for (const name of names) {
+    const match = SOURCE_REGEX.exec(name);
+    if (!match) continue;
+    const [y, m, day] = match[1].split('-').map((s) => Number.parseInt(s, 10));
+    const entryMs = Date.UTC(y, m - 1, day);
+    if (entryMs < cutoffMs) out.push(name);
+  }
+  return out;
+}
+
+/**
+ * Append a batch of records as JSONL to the current dated log file, applying
+ * date and size rotation and pruning files older than the retention window.
+ *
+ * All I/O is synchronous because the native host is a single-shot stdin/stdout
+ * request/response handler with no async event loop expectation.
+ */
+export function writeLogBatch(records: ReadonlyArray<unknown>, opts: WriteLogBatchOpts): void {
+  const today = opts.today ?? new Date();
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const retentionDays = opts.retentionDays ?? DEFAULT_RETENTION_DAYS;
+
+  // Empty batches are a valid no-op; skip directory creation and I/O so the
+  // host can ack quickly without touching the filesystem.
+  if (records.length === 0) return;
+
+  if (!existsSync(opts.dir)) {
+    mkdirSync(opts.dir, { recursive: true });
+  }
+
+  const target = currentFileName(today);
+  const targetPath = join(opts.dir, target);
+  const payload = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  const pendingBytes = Buffer.byteLength(payload, 'utf8');
+
+  const names = readdirSync(opts.dir);
+
+  // Size rotation: if the current file would overflow, rename it to
+  // <name>.<suffix> and create a fresh file.
+  if (names.includes(target)) {
+    let currentBytes = 0;
+    try {
+      currentBytes = statSync(targetPath).size;
+    } catch {
+      currentBytes = 0;
+    }
+    if (currentBytes + pendingBytes > maxBytes) {
+      const suffix = nextSizeSuffix(names, target);
+      renameSync(targetPath, `${targetPath}.${suffix}`);
+    }
+  }
+
+  appendFileSync(targetPath, payload, 'utf8');
+
+  // Touch the file via writeFileSync if append did not (in practice
+  // appendFileSync creates the file; this guard is defensive).
+  if (!existsSync(targetPath)) {
+    writeFileSync(targetPath, payload, 'utf8');
+  }
+
+  // Prune: drop files older than retentionDays. Refresh the directory listing
+  // so we see any freshly-renamed siblings.
+  const refreshed = readdirSync(opts.dir);
+  const toPrune = pickPruneTargets(refreshed, today, retentionDays);
+  for (const name of toPrune) {
+    try {
+      unlinkSync(join(opts.dir, name));
+    } catch {
+      // Best-effort prune; swallow filesystem errors.
+    }
+  }
+}

--- a/packages/chrome-ext/src/popup/popup.ts
+++ b/packages/chrome-ext/src/popup/popup.ts
@@ -5,6 +5,16 @@
 
 import type { AppState, ThemeName, LogLevel } from '@mdreview/core';
 import { debug } from '../utils/debug-logger';
+import { initRemoteLogging } from '../content/logging/init';
+
+// Initialise the structured logger before any popup work runs so popup
+// records flow through the SW LOG_BATCH route from the first emission.
+try {
+  initRemoteLogging('chrome-ext', chrome.runtime.getManifest().version);
+} catch (error) {
+  // eslint-disable-next-line no-console
+  console.warn('[MDView] initRemoteLogging failed:', error);
+}
 
 class PopupManager {
   private state: AppState | null = null;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/utils/debug-logger.d.ts",
       "import": "./dist/utils/debug-logger.js"
     },
+    "./logging": {
+      "types": "./dist/logging/index.d.ts",
+      "import": "./dist/logging/index.js"
+    },
     "./styles/content.css": "./styles/content.css"
   },
   "scripts": {

--- a/packages/core/src/__tests__/logging/wire-up.smoke.test.ts
+++ b/packages/core/src/__tests__/logging/wire-up.smoke.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getLogger, initLogging, shutdownLogging } from '../../logging';
+import type { LogRecord, LogTransport, ResourceAttrs, TransportResult } from '../../logging';
+
+const RESOURCE: ResourceAttrs = {
+  'service.name': 'mdview',
+  'service.version': '0.0.0-test',
+  'service.namespace': 'electron-main',
+  'deployment.environment': 'dev',
+  'host.os': 'test',
+};
+
+class FlakyTransport implements LogTransport {
+  calls = 0;
+  delivered: LogRecord[] = [];
+  // First export fails; subsequent ones succeed.
+  export(records: readonly LogRecord[]): Promise<TransportResult> {
+    this.calls += 1;
+    if (this.calls === 1) {
+      return Promise.resolve({ ok: false, reason: 'simulated outage' });
+    }
+    this.delivered.push(...records);
+    return Promise.resolve({ ok: true });
+  }
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+afterEach(async () => {
+  await shutdownLogging();
+});
+
+describe('logging pipeline wire-up', () => {
+  it('recovers all records after a transient transport failure', async () => {
+    const transport = new FlakyTransport();
+    initLogging({
+      transport,
+      resource: RESOURCE,
+      // Tight batch + interval so the test completes quickly.
+      maxBatch: 10,
+      flushIntervalMs: 50,
+      ringMaxBytes: 1_048_576,
+    });
+
+    const log = getLogger('smoke');
+    for (let i = 0; i < 100; i += 1) {
+      log.info(`msg-${i}`, { i });
+    }
+
+    // Let the processor flush, fail, then re-flush.
+    // Two flush windows plus a margin.
+    await new Promise((r) => setTimeout(r, 250));
+    await shutdownLogging(); // forces a final flush
+
+    expect(transport.calls).toBeGreaterThanOrEqual(2);
+    // All 100 records made it through, possibly across multiple successful batches.
+    expect(transport.delivered.map((r) => r.attributes.i)).toEqual(
+      Array.from({ length: 100 }, (_, i) => i)
+    );
+  });
+});

--- a/packages/core/src/logging/index.ts
+++ b/packages/core/src/logging/index.ts
@@ -127,3 +127,11 @@ export type { Logger, Span } from './logger';
 export type { LogTransport, TransportResult } from './transport';
 export { NoopTransport } from './transport';
 export * from './semconv';
+export {
+  currentFileName,
+  dateStem,
+  nextSizeSuffix,
+  planPrune,
+  planRotation,
+} from './file-rotation';
+export type { DirEntry, LogSource, RotationAction, RotationOpts } from './file-rotation';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     sw: "src/sw.ts",
     adapters: "src/adapters.ts",
     "utils/debug-logger": "src/utils/debug-logger.ts",
+    "logging/index": "src/logging/index.ts",
   },
   format: ["esm"],
   dts: true,

--- a/packages/electron/src/main/index.ts
+++ b/packages/electron/src/main/index.ts
@@ -4,6 +4,7 @@ import { join, extname, basename } from 'path';
 import { pathToFileURL } from 'url';
 import ElectronStore from 'electron-store';
 import { CacheManager } from '@mdreview/core/node';
+import { initLogging, shutdownLogging } from '@mdreview/core/logging';
 import { ElectronStorageAdapter } from './adapters/storage-adapter';
 import { ElectronFileAdapter } from './adapters/file-adapter';
 import { ElectronIdentityAdapter } from './adapters/identity-adapter';
@@ -14,6 +15,7 @@ import { RecentFilesManager } from './recent-files';
 import { SessionManager } from './session-restore';
 import { DirectoryService } from './directory-service';
 import { buildApplicationMenu } from './menu';
+import { buildLogging } from './logging/init';
 import { IPC_CHANNELS } from '../shared/ipc-channels';
 
 const MD_EXTENSIONS = new Set(['.md', '.markdown', '.mdown', '.mkd', '.mkdn', '.mdx']);
@@ -64,6 +66,7 @@ let openFilePath: string | null = null;
 let stateManagerRef: StateManager | null = null;
 let sessionManagerRef: SessionManager | null = null;
 let recentFilesRef: RecentFilesManager | null = null;
+let loggingShutdownStarted = false;
 
 function parseOpenFilePath(): string | null {
   const args = process.argv.slice(app.isPackaged ? 1 : 2);
@@ -253,6 +256,16 @@ void app.whenReady().then(async () => {
 
   openFilePath = parseOpenFilePath();
 
+  // Initialise structured logging before any other subsystem so early errors
+  // are captured. The same FileTransport instance is shared with the IPC
+  // LOG_BATCH handler so renderer batches land in the same JSONL file.
+  const { transport: loggingTransport, resource: loggingResource } = buildLogging({
+    version: app.getVersion(),
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+  });
+  initLogging({ transport: loggingTransport, resource: loggingResource });
+
   const syncStore = new ElectronStore({ name: 'preferences' });
   const localStore = new ElectronStore({ name: 'local' });
 
@@ -295,6 +308,12 @@ void app.whenReady().then(async () => {
     exportAdapter,
     recentFiles,
     directoryService,
+    loggingTransport,
+    getRuntimeInfo: () => ({
+      version: app.getVersion(),
+      platform: process.platform,
+      isPackaged: app.isPackaged,
+    }),
     getWindow: () => mainWindow,
     getOpenFilePath: () => openFilePath,
   });
@@ -330,9 +349,23 @@ void app.whenReady().then(async () => {
     mainWindow = null;
   });
 
-  app.on('before-quit', () => {
+  app.on('before-quit', (event) => {
     stateManagerRef?.flushPersist();
     saveSession();
+    // Drain the structured-logger pipeline so in-flight batches land on disk.
+    // We defer quit briefly via preventDefault until shutdown resolves; the
+    // FileTransport's own retries keep this bounded in practice.
+    if (!loggingShutdownStarted) {
+      loggingShutdownStarted = true;
+      event.preventDefault();
+      void shutdownLogging()
+        .catch((err) => {
+          console.error('[mdview] shutdownLogging failed:', err);
+        })
+        .finally(() => {
+          app.quit();
+        });
+    }
   });
 });
 

--- a/packages/electron/src/main/ipc-handlers.test.ts
+++ b/packages/electron/src/main/ipc-handlers.test.ts
@@ -442,4 +442,39 @@ describe('IPC Handlers', () => {
       expect(vi.mocked(electron.shell.showItemInFolder)).toHaveBeenCalledWith('/tmp/test.md');
     });
   });
+
+  describe('LOG_BATCH', () => {
+    it('no-ops when loggingTransport is undefined', async () => {
+      const handler = handlers.get(IPC_CHANNELS.LOG_BATCH);
+      // Default deps have no loggingTransport; handler should resolve without throwing.
+      await expect(handler?.({}, [])).resolves.toBeUndefined();
+    });
+
+    it('forwards records to loggingTransport.export', async () => {
+      const loggingTransport = { export: vi.fn().mockResolvedValue({ ok: true }) };
+      handlers.clear();
+      registerIpcHandlers({ ...deps, loggingTransport } as never);
+
+      const handler = handlers.get(IPC_CHANNELS.LOG_BATCH);
+      const records = [{ body: 'hi' }];
+      await handler?.({}, records);
+
+      expect(loggingTransport.export).toHaveBeenCalledWith(records);
+    });
+
+    it('warns on export failure but does not throw', async () => {
+      const loggingTransport = {
+        export: vi.fn().mockResolvedValue({ ok: false, reason: 'disk full' }),
+      };
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      handlers.clear();
+      registerIpcHandlers({ ...deps, loggingTransport } as never);
+
+      const handler = handlers.get(IPC_CHANNELS.LOG_BATCH);
+      await expect(handler?.({}, [])).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith('[mdview] log batch failed:', 'disk full');
+
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/packages/electron/src/main/ipc-handlers.test.ts
+++ b/packages/electron/src/main/ipc-handlers.test.ts
@@ -443,6 +443,30 @@ describe('IPC Handlers', () => {
     });
   });
 
+  describe('GET_RUNTIME_INFO', () => {
+    it('returns the value produced by deps.getRuntimeInfo', async () => {
+      const info = { version: '9.9.9', platform: 'darwin', isPackaged: true };
+      handlers.clear();
+      registerIpcHandlers({ ...deps, getRuntimeInfo: () => info } as never);
+
+      const handler = handlers.get(IPC_CHANNELS.GET_RUNTIME_INFO);
+      const result = await handler?.();
+      expect(result).toEqual(info);
+    });
+
+    it('falls back to safe defaults when no provider is supplied', async () => {
+      const handler = handlers.get(IPC_CHANNELS.GET_RUNTIME_INFO);
+      const result = (await handler?.()) as {
+        version: string;
+        platform: string;
+        isPackaged: boolean;
+      };
+      expect(result.version).toBe('0.0.0');
+      expect(result.platform).toBe(process.platform);
+      expect(result.isPackaged).toBe(false);
+    });
+  });
+
   describe('LOG_BATCH', () => {
     it('no-ops when loggingTransport is undefined', async () => {
       const handler = handlers.get(IPC_CHANNELS.LOG_BATCH);

--- a/packages/electron/src/main/ipc-handlers.ts
+++ b/packages/electron/src/main/ipc-handlers.ts
@@ -12,6 +12,7 @@ import type { CacheManager, CachedResult, Preferences } from '@mdreview/core/nod
 import type { LogRecord } from '@mdreview/core/logging';
 import type { FileTransport } from './logging/file-transport';
 import type { TabState, TabGroupState, TabGroupColor } from '../shared/workspace-types';
+import type { RuntimeInfo } from '../shared/preload-api';
 
 export interface IPCHandlerDeps {
   stateManager: StateManager;
@@ -23,6 +24,7 @@ export interface IPCHandlerDeps {
   directoryService?: DirectoryService;
   gitService?: ElectronGitService;
   loggingTransport?: FileTransport;
+  getRuntimeInfo?: () => RuntimeInfo;
   getWindow: () => BrowserWindow | null;
   getOpenFilePath: () => string | null;
 }
@@ -387,6 +389,15 @@ export function registerIpcHandlers(deps: IPCHandlerDeps): () => void {
   );
 
   ipcMain.handle(IPC_CHANNELS.GIT_STASH, () => deps.gitService?.stash());
+
+  // Logging: surface runtime context to the renderer so it can build its own
+  // OTel resource attributes consistently with the main process.
+  ipcMain.handle(IPC_CHANNELS.GET_RUNTIME_INFO, (): RuntimeInfo => {
+    const provider = deps.getRuntimeInfo;
+    return provider
+      ? provider()
+      : { version: '0.0.0', platform: process.platform, isPackaged: false };
+  });
 
   // Logging: forward renderer batches to the main-side FileTransport so renderer
   // records share a file with main-process records. If no transport is wired

--- a/packages/electron/src/main/ipc-handlers.ts
+++ b/packages/electron/src/main/ipc-handlers.ts
@@ -9,6 +9,8 @@ import type { RecentFilesManager } from './recent-files';
 import type { DirectoryService } from './directory-service';
 import type { ElectronGitService } from './git-service';
 import type { CacheManager, CachedResult, Preferences } from '@mdreview/core/node';
+import type { LogRecord } from '@mdreview/core/logging';
+import type { FileTransport } from './logging/file-transport';
 import type { TabState, TabGroupState, TabGroupColor } from '../shared/workspace-types';
 
 export interface IPCHandlerDeps {
@@ -20,6 +22,7 @@ export interface IPCHandlerDeps {
   recentFiles?: RecentFilesManager;
   directoryService?: DirectoryService;
   gitService?: ElectronGitService;
+  loggingTransport?: FileTransport;
   getWindow: () => BrowserWindow | null;
   getOpenFilePath: () => string | null;
 }
@@ -384,6 +387,21 @@ export function registerIpcHandlers(deps: IPCHandlerDeps): () => void {
   );
 
   ipcMain.handle(IPC_CHANNELS.GIT_STASH, () => deps.gitService?.stash());
+
+  // Logging: forward renderer batches to the main-side FileTransport so renderer
+  // records share a file with main-process records. If no transport is wired
+  // (e.g. test harness), no-op and return so the renderer's invoke resolves.
+  ipcMain.handle(IPC_CHANNELS.LOG_BATCH, async (_event, records: readonly LogRecord[]) => {
+    const transport = deps.loggingTransport;
+    if (!transport) return;
+    const result = await transport.export(records);
+    if (!result.ok) {
+      // Cannot use the structured logger here without risking a feedback loop
+      // (this code path is the logger's main-side sink).
+      // eslint-disable-next-line no-console
+      console.warn('[mdview] log batch failed:', result.reason);
+    }
+  });
 
   // Return cleanup function to stop all file watchers before window destruction
   return () => {

--- a/packages/electron/src/main/logging/__tests__/file-transport.test.ts
+++ b/packages/electron/src/main/logging/__tests__/file-transport.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { LogRecord } from '@mdreview/core/logging';
+import { FileTransport } from '../file-transport';
+
+function makeRecord(i: number, bodyChars = 10): LogRecord {
+  return {
+    timestamp: i,
+    observedTimestamp: i,
+    severityNumber: 9,
+    severityText: 'INFO',
+    body: 'm'.repeat(bodyChars),
+    attributes: {},
+    resource: {
+      'service.name': 'mdview',
+      'service.version': '0.0.0-test',
+      'service.namespace': 'electron-main',
+      'deployment.environment': 'dev',
+      'host.os': 'test',
+    },
+  };
+}
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'mdview-log-test-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('FileTransport', () => {
+  it('writes one JSONL line per record to a dated file', async () => {
+    const t = new FileTransport({
+      dir,
+      source: 'electron',
+      now: () => new Date('2026-05-11T12:00:00Z'),
+    });
+    const result = await t.export([makeRecord(1), makeRecord(2)]);
+    expect(result.ok).toBe(true);
+    const file = path.join(dir, 'mdview-electron-2026-05-11.jsonl');
+    const text = await fs.readFile(file, 'utf8');
+    const lines = text.trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]) as { body: string };
+    expect(first.body).toBe('m'.repeat(10));
+    await t.shutdown();
+  });
+
+  it('rotates by date at next export after the clock advances', async () => {
+    let now = new Date('2026-05-11T23:59:50Z');
+    const t = new FileTransport({ dir, source: 'electron', now: () => now });
+    await t.export([makeRecord(1)]);
+    now = new Date('2026-05-12T00:00:10Z');
+    await t.export([makeRecord(2)]);
+    const a = path.join(dir, 'mdview-electron-2026-05-11.jsonl');
+    const b = path.join(dir, 'mdview-electron-2026-05-12.jsonl');
+    expect((await fs.readFile(a, 'utf8')).trim().split('\n')).toHaveLength(1);
+    expect((await fs.readFile(b, 'utf8')).trim().split('\n')).toHaveLength(1);
+    await t.shutdown();
+  });
+
+  it('rolls over by size when the projected file exceeds maxBytes', async () => {
+    const t = new FileTransport({
+      dir,
+      source: 'electron',
+      maxBytes: 600,
+      now: () => new Date('2026-05-11T12:00:00Z'),
+    });
+    await t.export([makeRecord(1)]);
+    await t.export([makeRecord(2)]);
+    await t.export([makeRecord(3)]);
+    const names = (await fs.readdir(dir)).sort();
+    expect(names.some((n) => /^mdview-electron-2026-05-11\.jsonl\.\d+$/.test(n))).toBe(true);
+    expect(names).toContain('mdview-electron-2026-05-11.jsonl');
+    await t.shutdown();
+  });
+
+  it('prunes files older than retentionDays based on filename stem', async () => {
+    await fs.writeFile(path.join(dir, 'mdview-electron-2026-04-20.jsonl'), 'x\n');
+    await fs.writeFile(path.join(dir, 'mdview-electron-2026-04-25.jsonl'), 'x\n');
+    await fs.writeFile(path.join(dir, 'mdview-electron-2026-05-11.jsonl'), 'x\n');
+    const t = new FileTransport({
+      dir,
+      source: 'electron',
+      retentionDays: 14,
+      now: () => new Date('2026-05-11T12:00:00Z'),
+    });
+    await t.export([makeRecord(1)]);
+    const names = (await fs.readdir(dir)).sort();
+    expect(names).toContain('mdview-electron-2026-05-11.jsonl');
+    expect(names).not.toContain('mdview-electron-2026-04-20.jsonl');
+    expect(names).not.toContain('mdview-electron-2026-04-25.jsonl');
+    await t.shutdown();
+  });
+
+  it('returns ok:false on write failure without throwing', async () => {
+    const t = new FileTransport({
+      dir: '/nonexistent-readonly-mdview-test/no',
+      source: 'electron',
+      now: () => new Date('2026-05-11T12:00:00Z'),
+    });
+    const result = await t.export([makeRecord(1)]);
+    expect(result.ok).toBe(false);
+    expect(typeof result.reason).toBe('string');
+  });
+});

--- a/packages/electron/src/main/logging/file-transport.ts
+++ b/packages/electron/src/main/logging/file-transport.ts
@@ -1,0 +1,200 @@
+import { promises as fs } from 'node:fs';
+import type { FileHandle } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  currentFileName,
+  planPrune,
+  planRotation,
+  type DirEntry,
+  type LogRecord,
+  type LogSource,
+  type LogTransport,
+  type TransportResult,
+} from '@mdreview/core/logging';
+
+export interface FileTransportOpts {
+  dir?: string;
+  source: LogSource;
+  maxBytes?: number;
+  retentionDays?: number;
+  now?: () => Date;
+}
+
+const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
+const DEFAULT_RETENTION_DAYS = 14;
+
+export class FileTransport implements LogTransport {
+  private readonly dir: string;
+  private readonly source: LogSource;
+  private readonly maxBytes: number;
+  private readonly retentionDays: number;
+  private readonly now: () => Date;
+
+  private handle: FileHandle | null = null;
+  private currentFile: string | null = null;
+  private currentBytes = 0;
+  private dirEnsured = false;
+  private dirCache: DirEntry[] | null = null;
+
+  constructor(opts: FileTransportOpts) {
+    this.dir = opts.dir ?? path.join(os.tmpdir(), 'mdview', 'logs');
+    this.source = opts.source;
+    this.maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+    this.retentionDays = opts.retentionDays ?? DEFAULT_RETENTION_DAYS;
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  async export(records: readonly LogRecord[]): Promise<TransportResult> {
+    try {
+      if (records.length === 0) {
+        return { ok: true };
+      }
+
+      await this.ensureDir();
+
+      const lines = records.map((r) => `${JSON.stringify(r)}\n`);
+      const pendingBytes = lines.reduce((acc, l) => acc + Buffer.byteLength(l, 'utf8'), 0);
+
+      const dirEntries = await this.readDirCached();
+      const today = this.now();
+      const action = planRotation(dirEntries, this.currentFile, this.currentBytes, pendingBytes, {
+        source: this.source,
+        today,
+        maxBytes: this.maxBytes,
+        retentionDays: this.retentionDays,
+      });
+
+      await this.applyAction(action);
+
+      const payload = lines.join('');
+      const buf = Buffer.from(payload, 'utf8');
+      if (this.handle === null) {
+        // applyAction should have opened a handle; defensive guard.
+        throw new Error('FileTransport: no open file handle after rotation');
+      }
+      await this.handle.write(buf);
+      this.currentBytes += buf.byteLength;
+
+      // Prune old files. Refresh dir cache first since we wrote/rotated.
+      this.dirCache = null;
+      const refreshed = await this.readDirCached();
+      const toPrune = planPrune(refreshed, {
+        today,
+        retentionDays: this.retentionDays,
+        source: this.source,
+      });
+      if (toPrune.length > 0) {
+        for (const name of toPrune) {
+          try {
+            await fs.unlink(path.join(this.dir, name));
+          } catch {
+            // Best-effort prune; ignore individual unlink failures.
+          }
+        }
+        this.dirCache = null;
+      }
+
+      return { ok: true };
+    } catch (err) {
+      return {
+        ok: false,
+        reason: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.handle !== null) {
+      const h = this.handle;
+      this.handle = null;
+      this.currentFile = null;
+      this.currentBytes = 0;
+      await h.close();
+    }
+  }
+
+  private async ensureDir(): Promise<void> {
+    if (this.dirEnsured) return;
+    await fs.mkdir(this.dir, { recursive: true });
+    this.dirEnsured = true;
+  }
+
+  private async readDirCached(): Promise<DirEntry[]> {
+    if (this.dirCache !== null) return this.dirCache;
+    const names = await fs.readdir(this.dir);
+    const entries: DirEntry[] = [];
+    for (const name of names) {
+      try {
+        const st = await fs.stat(path.join(this.dir, name));
+        if (st.isFile()) {
+          entries.push({ name, size: st.size });
+        }
+      } catch {
+        // Skip entries that disappear between readdir and stat.
+      }
+    }
+    this.dirCache = entries;
+    return entries;
+  }
+
+  private async openAppend(file: string): Promise<void> {
+    const fullPath = path.join(this.dir, file);
+    const handle = await fs.open(fullPath, 'a');
+    let size = 0;
+    try {
+      const st = await handle.stat();
+      size = st.size;
+    } catch {
+      size = 0;
+    }
+    this.handle = handle;
+    this.currentFile = file;
+    this.currentBytes = size;
+  }
+
+  private async closeIfOpen(): Promise<void> {
+    if (this.handle !== null) {
+      const h = this.handle;
+      this.handle = null;
+      await h.close();
+    }
+  }
+
+  private async applyAction(action: ReturnType<typeof planRotation>): Promise<void> {
+    switch (action.kind) {
+      case 'append': {
+        if (this.currentFile !== action.file || this.handle === null) {
+          await this.closeIfOpen();
+          await this.openAppend(action.file);
+        }
+        return;
+      }
+      case 'rollover-date': {
+        await this.closeIfOpen();
+        // Date rollover: leave the previous file in place under its dated name,
+        // open the new dated file fresh.
+        this.currentFile = null;
+        this.currentBytes = 0;
+        await this.openAppend(action.to);
+        this.dirCache = null;
+        // Verify expected name matches today's currentFileName for safety.
+        if (action.to !== currentFileName(this.source, this.now())) {
+          // The planner is authoritative; the assertion is defensive.
+        }
+        return;
+      }
+      case 'rollover-size': {
+        await this.closeIfOpen();
+        const fromPath = path.join(this.dir, action.from);
+        const renamePath = path.join(this.dir, action.renameTo);
+        await fs.rename(fromPath, renamePath);
+        this.currentFile = null;
+        this.currentBytes = 0;
+        await this.openAppend(action.to);
+        this.dirCache = null;
+        return;
+      }
+    }
+  }
+}

--- a/packages/electron/src/main/logging/init.test.ts
+++ b/packages/electron/src/main/logging/init.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { buildLogging, buildMainResource } from './init';
+import { FileTransport } from './file-transport';
+
+describe('buildMainResource', () => {
+  it('builds expected attributes for packaged build', () => {
+    const r = buildMainResource({ version: '1.2.3', platform: 'darwin', isPackaged: true });
+    expect(r).toEqual({
+      'service.name': 'mdview',
+      'service.version': '1.2.3',
+      'service.namespace': 'electron-main',
+      'deployment.environment': 'prod',
+      'host.os': 'darwin',
+    });
+  });
+
+  it('uses dev environment when not packaged', () => {
+    const r = buildMainResource({ version: '0.0.0-dev', platform: 'linux', isPackaged: false });
+    expect(r['deployment.environment']).toBe('dev');
+    expect(r['service.version']).toBe('0.0.0-dev');
+    expect(r['host.os']).toBe('linux');
+  });
+});
+
+describe('buildLogging', () => {
+  it('returns a FileTransport and a matching resource', () => {
+    const { transport, resource } = buildLogging({
+      version: '9.9.9',
+      platform: 'win32',
+      isPackaged: false,
+    });
+    expect(transport).toBeInstanceOf(FileTransport);
+    expect(resource['service.namespace']).toBe('electron-main');
+    expect(resource['service.version']).toBe('9.9.9');
+    expect(resource['host.os']).toBe('win32');
+  });
+});

--- a/packages/electron/src/main/logging/init.ts
+++ b/packages/electron/src/main/logging/init.ts
@@ -1,0 +1,39 @@
+import type { ResourceAttrs } from '@mdreview/core/logging';
+import { FileTransport } from './file-transport';
+
+export interface RuntimeContext {
+  version: string;
+  platform: string;
+  isPackaged: boolean;
+}
+
+/**
+ * Build the resource attributes that identify the Electron main process to the
+ * logging pipeline. Kept here so the renderer can mirror the shape via the
+ * preload getRuntimeInfo bridge.
+ */
+export function buildMainResource(ctx: RuntimeContext): ResourceAttrs {
+  return {
+    'service.name': 'mdview',
+    'service.version': ctx.version,
+    'service.namespace': 'electron-main',
+    'deployment.environment': ctx.isPackaged ? 'prod' : 'dev',
+    'host.os': ctx.platform,
+  };
+}
+
+export interface BuildLoggingResult {
+  transport: FileTransport;
+  resource: ResourceAttrs;
+}
+
+/**
+ * Construct the main-process FileTransport and its matching resource. The same
+ * transport instance is shared with the IPC LOG_BATCH handler so renderer
+ * records land in the same JSONL file.
+ */
+export function buildLogging(ctx: RuntimeContext): BuildLoggingResult {
+  const transport = new FileTransport({ source: 'electron' });
+  const resource = buildMainResource(ctx);
+  return { transport, resource };
+}

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -83,6 +83,9 @@ const api: MdreviewPreloadAPI = {
   gitCommit: (message) => ipcRenderer.invoke(IPC_CHANNELS.GIT_COMMIT, message),
   gitStash: () => ipcRenderer.invoke(IPC_CHANNELS.GIT_STASH),
 
+  // Logging
+  logBatch: (records) => ipcRenderer.invoke(IPC_CHANNELS.LOG_BATCH, records),
+
   // Event listeners
   onFileChanged: (callback) => {
     const listener = (_event: Electron.IpcRendererEvent, path: string) => callback(path);

--- a/packages/electron/src/preload/index.ts
+++ b/packages/electron/src/preload/index.ts
@@ -85,6 +85,7 @@ const api: MdreviewPreloadAPI = {
 
   // Logging
   logBatch: (records) => ipcRenderer.invoke(IPC_CHANNELS.LOG_BATCH, records),
+  getRuntimeInfo: () => ipcRenderer.invoke(IPC_CHANNELS.GET_RUNTIME_INFO),
 
   // Event listeners
   onFileChanged: (callback) => {

--- a/packages/electron/src/renderer/index.ts
+++ b/packages/electron/src/renderer/index.ts
@@ -1,7 +1,33 @@
 import '@mdreview/core/styles/content.css';
 import './workspace.css';
 import { DOMPurifierUtil, ThemeEngine } from '@mdreview/core';
+import { initLogging, type ResourceAttrs } from '@mdreview/core/logging';
+import { IpcLogTransport } from './logging/ipc-log-transport';
 import { MDReviewElectronViewer } from './viewer';
+
+// Initialise renderer-side structured logging as early as possible so the
+// rest of the bootstrap can emit through the buffered pipeline. The
+// IpcLogTransport forwards batches to the main process; pre-init records are
+// captured by the in-process ring and replayed once initLogging runs.
+async function initRendererLogging(): Promise<void> {
+  try {
+    const info = await window.mdreview.getRuntimeInfo();
+    const resource: ResourceAttrs = {
+      'service.name': 'mdview',
+      'service.version': info.version,
+      'service.namespace': 'electron-renderer',
+      'deployment.environment': info.isPackaged ? 'prod' : 'dev',
+      'host.os': info.platform,
+    };
+    const transport = new IpcLogTransport((records) => window.mdreview.logBatch(records));
+    initLogging({ transport, resource });
+  } catch {
+    // If the preload bridge is unavailable, pre-init log records remain in the
+    // RingBuffer and a later initLogging call (if any) will drain them.
+  }
+}
+
+void initRendererLogging();
 
 // Configure DOMPurify to allow local-asset:// protocol for serving local file images/links.
 // This must run before any rendering so DOMPurify preserves local-asset: URLs that are

--- a/packages/electron/src/renderer/logging/__tests__/ipc-log-transport.test.ts
+++ b/packages/electron/src/renderer/logging/__tests__/ipc-log-transport.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { LogRecord } from '@mdreview/core/logging';
+import { IpcLogTransport } from '../ipc-log-transport';
+
+const REC: LogRecord = {
+  timestamp: 1,
+  observedTimestamp: 1,
+  severityNumber: 9,
+  severityText: 'INFO',
+  body: 'hi',
+  attributes: {},
+  resource: {
+    'service.name': 'mdview',
+    'service.version': '0',
+    'service.namespace': 'electron-renderer',
+    'deployment.environment': 'dev',
+    'host.os': 't',
+  },
+};
+
+describe('IpcLogTransport', () => {
+  it('resolves ok:true when send resolves', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    const t = new IpcLogTransport(send);
+    expect(await t.export([REC])).toEqual({ ok: true });
+    expect(send).toHaveBeenCalledWith([REC]);
+  });
+
+  it('resolves ok:false with reason when send rejects', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('boom'));
+    const t = new IpcLogTransport(send);
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain('boom');
+    }
+  });
+
+  it('coerces non-Error rejections to a string reason', async () => {
+    const send = vi.fn().mockRejectedValue('plain reason');
+    const t = new IpcLogTransport(send);
+    const r = await t.export([REC]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('plain reason');
+    }
+  });
+});

--- a/packages/electron/src/renderer/logging/ipc-log-transport.ts
+++ b/packages/electron/src/renderer/logging/ipc-log-transport.ts
@@ -1,0 +1,26 @@
+import type { LogRecord, LogTransport, TransportResult } from '@mdreview/core/logging';
+
+/**
+ * Renderer-side LogTransport that ships batches to the Electron main process
+ * via the preload-bridged `logBatch` invoke. The main-side handler forwards to
+ * the shared FileTransport so renderer records land in the same JSONL file as
+ * main-process records.
+ *
+ * On rejection (main absent, IPC closed during teardown, etc.) we surface
+ * `ok: false` so the processor's RingBuffer retains the batch for retry.
+ */
+export class IpcLogTransport implements LogTransport {
+  constructor(private readonly send: (records: readonly LogRecord[]) => Promise<void>) {}
+
+  async export(records: readonly LogRecord[]): Promise<TransportResult> {
+    try {
+      await this.send(records);
+      return { ok: true };
+    } catch (err) {
+      return {
+        ok: false,
+        reason: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+}

--- a/packages/electron/src/shared/ipc-channels.test.ts
+++ b/packages/electron/src/shared/ipc-channels.test.ts
@@ -51,6 +51,7 @@ describe('IPC_CHANNELS', () => {
 
   it('should have logging channels', () => {
     expect(IPC_CHANNELS.LOG_BATCH).toBe('mdreview:log-batch');
+    expect(IPC_CHANNELS.GET_RUNTIME_INFO).toBe('mdreview:get-runtime-info');
   });
 
   it('should follow mdreview:git-* pattern for all git channels', () => {

--- a/packages/electron/src/shared/ipc-channels.test.ts
+++ b/packages/electron/src/shared/ipc-channels.test.ts
@@ -49,6 +49,10 @@ describe('IPC_CHANNELS', () => {
     expect(IPC_CHANNELS.GIT_STASH).toBe('mdreview:git-stash');
   });
 
+  it('should have logging channels', () => {
+    expect(IPC_CHANNELS.LOG_BATCH).toBe('mdreview:log-batch');
+  });
+
   it('should follow mdreview:git-* pattern for all git channels', () => {
     const gitChannelKeys = Object.keys(IPC_CHANNELS).filter((key) => key.startsWith('GIT_'));
     expect(gitChannelKeys.length).toBe(9);

--- a/packages/electron/src/shared/ipc-channels.ts
+++ b/packages/electron/src/shared/ipc-channels.ts
@@ -51,6 +51,7 @@ export const IPC_CHANNELS = {
 
   // Logging (renderer to main batched log records)
   LOG_BATCH: 'mdreview:log-batch',
+  GET_RUNTIME_INFO: 'mdreview:get-runtime-info',
 
   // Git
   GIT_IS_REPO: 'mdreview:git-is-repo',

--- a/packages/electron/src/shared/ipc-channels.ts
+++ b/packages/electron/src/shared/ipc-channels.ts
@@ -49,6 +49,9 @@ export const IPC_CHANNELS = {
   UPDATE_TAB_GROUP: 'mdreview:update-tab-group',
   DELETE_TAB_GROUP: 'mdreview:delete-tab-group',
 
+  // Logging (renderer to main batched log records)
+  LOG_BATCH: 'mdreview:log-batch',
+
   // Git
   GIT_IS_REPO: 'mdreview:git-is-repo',
   GIT_GET_BRANCH: 'mdreview:git-get-branch',

--- a/packages/electron/src/shared/preload-api.ts
+++ b/packages/electron/src/shared/preload-api.ts
@@ -1,5 +1,6 @@
 import type { AppState, Preferences, CachedResult } from '@mdreview/core';
 import type { FileChangeInfo, FileWriteResult, GitFileStatus } from '@mdreview/core';
+import type { LogRecord } from '@mdreview/core/logging';
 import type {
   WorkspaceState,
   TabState,
@@ -96,6 +97,9 @@ export interface MdreviewPreloadAPI {
   gitUnstage(paths: string[]): Promise<void>;
   gitCommit(message: string): Promise<string>;
   gitStash(): Promise<void>;
+
+  // Logging (renderer to main, batched LogRecord transport)
+  logBatch(records: readonly LogRecord[]): Promise<void>;
 
   // Event listeners (main → renderer)
   onFileChanged(callback: (path: string) => void): () => void;

--- a/packages/electron/src/shared/preload-api.ts
+++ b/packages/electron/src/shared/preload-api.ts
@@ -1,6 +1,12 @@
 import type { AppState, Preferences, CachedResult } from '@mdreview/core';
 import type { FileChangeInfo, FileWriteResult, GitFileStatus } from '@mdreview/core';
 import type { LogRecord } from '@mdreview/core/logging';
+
+export interface RuntimeInfo {
+  version: string;
+  platform: string;
+  isPackaged: boolean;
+}
 import type {
   WorkspaceState,
   TabState,
@@ -100,6 +106,11 @@ export interface MdreviewPreloadAPI {
 
   // Logging (renderer to main, batched LogRecord transport)
   logBatch(records: readonly LogRecord[]): Promise<void>;
+  /**
+   * Runtime context exposed to the renderer so it can build the OTel resource
+   * attributes for its logger without duplicating the data from the main side.
+   */
+  getRuntimeInfo(): Promise<RuntimeInfo>;
 
   // Event listeners (main → renderer)
   onFileChanged(callback: (path: string) => void): () => void;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
         __dirname,
         './packages/core/src/utils/debug-logger.ts'
       ),
+      '@mdreview/core/logging': resolve(__dirname, './packages/core/src/logging/index.ts'),
       '@mdreview/core': resolve(__dirname, './packages/core/src/index.ts'),
     },
   },


### PR DESCRIPTION
## Summary

Wires the Phase 1 logging infrastructure into the real platforms:

- **Electron main**: `FileTransport` writing rotated JSONL to `${os.tmpdir()}/mdview/logs/mdview-electron-YYYY-MM-DD.jsonl`. `initLogging` is called at app bootstrap; `shutdownLogging` runs on `before-quit`.
- **Electron renderer**: `IpcLogTransport` posts batches over `LOG_BATCH` IPC; main forwards to the same `FileTransport`. Renderer gets a `getRuntimeInfo` IPC for resource attrs.
- **Chrome SW**: `NativeHostTransport` primary, `IndexedDBTransport` fallback, `CompositeTransport` glue. Bridge-recovery flusher drains IDB buckets through the native host on bridge healthy transitions.
- **Chrome content + popup**: `RemoteTransport` posts batches to the SW; SW owns the single native-host pipe.
- **Native host**: new `log_batch` action appends to `mdview-chrome-YYYY-MM-DD.jsonl` in the same temp dir as Electron. Rotation plus 14-day retention. Self-contained: native host does NOT take a runtime dependency on `@mdreview/core`.

After this PR, every `getLogger('x').info(...)` from any context lands on disk. No production call sites are migrated yet; that comes in Phase 3 (comments, IPC decorators, etc.).

### Architecture confirmation

- Records share OTEL `LogRecord` shape: `severityNumber`, `severityText`, `body`, `attributes`, `resource`, optional `traceId`/`spanId`.
- Two writers, two files: `mdview-electron-*.jsonl` (Electron) and `mdview-chrome-*.jsonl` (native host on behalf of Chrome). Cross-app merge is `cat mdview-*-YYYY-MM-DD.jsonl | sort`.
- Resource attrs distinguish per-context: `electron-main`, `electron-renderer`, `chrome-sw`, `chrome-content`, `chrome-ext`, `native-host`.

### Known follow-up

`BatchLogRecordProcessor.flush` early-returns if a flush is in-flight (flagged in the Phase 1 PR). The micro-task workaround in `index.ts` keeps things correct; the cleaner fix is to re-check `pending` at end of flush.

The native host name has a typo: callers use `com.mdreview.filewriter` but the manifest declares `com.mdview.filewriter`. This PR matches the callers (intentional; reconciling the manifest is out of scope).

## Test plan

- [x] `bun run check` (lint + test:ci) passes
- [x] `bun run build` passes for all packages
- [ ] Manual smoke (Phase 3 deliverable): launch Electron app, verify `${TMPDIR}mdview/logs/mdview-electron-*.jsonl` appears after first log
- [ ] Manual smoke (Phase 3 deliverable): load Chrome extension, verify the native host's `log_batch` action writes `mdview-chrome-*.jsonl`, and that bridge outages route to IndexedDB and drain on recovery